### PR TITLE
Fix refraction slider value assignment

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -169,7 +169,7 @@ SetupWidget::SetupWidget(QWidget *parent)
         if (!isCustom) {
             int refractionValue = ui->cboRefraction->currentData().toInt();
             ui->spnRefraction->setValue(refractionValue / 100.0);
-            ui->sldRefraction->setEnabled(refractionValue);
+            ui->sldRefraction->setValue(refractionValue);
             m_profiles[m_currentProfile]->setRefraction(refractionValue);
         }
 


### PR DESCRIPTION
## Summary
- Set the refraction slider's value instead of toggling its enabled state when preset index changes
- Ensure the slider stays disabled unless a custom refraction index is selected

## Testing
- `cmake ..` *(fails: Qt6 not found/Qt translation macros error)*

------
https://chatgpt.com/codex/tasks/task_e_689d1187c380832883263501248271d1