### PR TITLE
Fix default emoji and emote paths

### DIFF
--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -78,8 +78,8 @@
 #define DEFAULT_CLIENT_ID "3x2mzlmm9mz8qpml51m5mxc8dbdk4d"
 
 #ifdef Q_OS_WIN
-# define DEFAULT_EMOJI_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emoteInfo")
-# define DEFAULT_EMOTE_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emojiInfo")
+# define DEFAULT_EMOJI_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emojiInfo")
+# define DEFAULT_EMOTE_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emoteInfo")
 # define DEFAULT_EMOJI_FONT "Segoe UI Emoji"
 #else
 # define DEFAULT_EMOJI_DIR QString("%1/%2").arg(qEnvironmentVariable("HOME"), ".atsumari/emojiInfo")


### PR DESCRIPTION
## Summary
- Correct default paths for emojis and emotes on Windows so both platforms use `emojiInfo` and `emoteInfo` consistently

## Testing
- `cmake -S . -B build` *(fails: Cannot add target-level dependencies to non-existent target "atsumari" and configure_file errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d113c32548328a6c6d010696e717a