### PR TITLE
Add configurable command visibility for logs

### DIFF
--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -57,7 +57,9 @@
 
 #define CFG_LOG_COLUMNS "log/columns"
 #define CFG_LOG_COLOR_PREFIX "log/colors/"
+#define CFG_LOG_HIDE_CMDS "log/hide"
 #define DEFAULT_LOG_COLUMNS (QStringList() << "Timestamp" << "Command" << "Badges" << "Sender" << "Message" << "Tags" << "Emotes")
+#define DEFAULT_LOG_HIDE_CMDS (QStringList() << "PING" << "PONG")
 
 #define DEFAULT_VERSION 1 // So we can migrate from v1
 #define DEFAULT_ROUGHNESS 0

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -96,6 +96,10 @@ void TwitchLogModel::addEntry(const QString &command,
                               const QList<QPixmap> &badges,
                               const QList<QPixmap> &emotes)
 {
+    QSettings settings;
+    QStringList hidden = settings.value(CFG_LOG_HIDE_CMDS, DEFAULT_LOG_HIDE_CMDS).toStringList();
+    if (hidden.contains(command))
+        return;
     beginInsertRows(QModelIndex(), m_entries.size(), m_entries.size());
     Entry e;
     e.timestamp = QDateTime::currentDateTime();


### PR DESCRIPTION
## Summary
- allow log settings to toggle visibility of commands, default hiding PING and PONG
- update Setup dialog to manage command visibility and save hidden list
- ignore hidden commands when appending entries to log model

## Testing
- `cmake ..` *(fails: Could not find required Qt component Quick3D)*

------
https://chatgpt.com/codex/tasks/task_e_68a00dbdf6e08328bff39b2fe55cd74d