### PR TITLE
Render emote sequences using a delegate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(PROJECT_SOURCES
         emojimapper.h emojimapper.cpp
         twitchlogmodel.h twitchlogmodel.cpp
         logviewdialog.h logviewdialog.cpp logviewdialog.ui
+        pixmapsequencedelegate.h pixmapsequencedelegate.cpp
 
         settings_defaults.h
         atsumarilauncher.h atsumarilauncher.cpp

--- a/logviewdialog.cpp
+++ b/logviewdialog.cpp
@@ -12,6 +12,7 @@
 
 #include "twitchlogmodel.h"
 #include "settings_defaults.h"
+#include "pixmapsequencedelegate.h"
 
 LogViewDialog::LogViewDialog(QWidget *parent)
     : QDialog(parent)
@@ -23,9 +24,7 @@ LogViewDialog::LogViewDialog(QWidget *parent)
     m_table->setModel(TwitchLogModel::instance());
     int size = m_table->verticalHeader()->defaultSectionSize();
     m_table->setIconSize(QSize(size, size));
-    connect(m_table->verticalHeader(), &QHeaderView::sectionResized, this, [=](int, int, int newSize){
-        m_table->setIconSize(QSize(newSize, newSize));
-    });
+    m_table->setItemDelegateForColumn(TwitchLogModel::Emotes, new PixmapSequenceDelegate(m_table));
     connect(m_exportButton, &QPushButton::clicked, this, [=]() {
         QString fn = QFileDialog::getSaveFileName(this, tr("Export logs"), QString(), tr("Text Files (*.txt)"));
         if (!fn.isEmpty()) {

--- a/pixmapsequencedelegate.cpp
+++ b/pixmapsequencedelegate.cpp
@@ -1,0 +1,43 @@
+#include "pixmapsequencedelegate.h"
+#include "twitchlogmodel.h"
+
+#include <QApplication>
+#include <QPainter>
+#include <QIcon>
+#include <QStyle>
+
+PixmapSequenceDelegate::PixmapSequenceDelegate(QObject *parent)
+    : QStyledItemDelegate(parent)
+{
+}
+
+void PixmapSequenceDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+                                   const QModelIndex &index) const
+{
+    QStyleOptionViewItem opt(option);
+    initStyleOption(&opt, index);
+    opt.icon = QIcon();
+
+    painter->save();
+    painter->setClipRect(opt.rect);
+
+    QStyle *style = opt.widget ? opt.widget->style() : QApplication::style();
+    style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, opt.widget);
+
+    QList<QPixmap> emotes = TwitchLogModel::instance()->emotesForRow(index.row());
+    if (!emotes.isEmpty()) {
+        int x = opt.rect.x();
+        int maxX = opt.rect.x() + opt.rect.width();
+        for (const QPixmap &p : emotes) {
+            QSize size = p.size();
+            size.scale(opt.rect.height(), opt.rect.height(), Qt::KeepAspectRatio);
+            QPixmap scaled = p.scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            if (x + scaled.width() > maxX)
+                break;
+            painter->drawPixmap(x, opt.rect.y() + (opt.rect.height() - scaled.height()) / 2, scaled);
+            x += scaled.width();
+        }
+    }
+
+    painter->restore();
+}

--- a/pixmapsequencedelegate.h
+++ b/pixmapsequencedelegate.h
@@ -1,0 +1,14 @@
+#ifndef PIXMAPSEQUENCEDELEGATE_H
+#define PIXMAPSEQUENCEDELEGATE_H
+
+#include <QStyledItemDelegate>
+
+class PixmapSequenceDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+public:
+    explicit PixmapSequenceDelegate(QObject *parent = nullptr);
+    void paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+};
+
+#endif // PIXMAPSEQUENCEDELEGATE_H

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -3,7 +3,6 @@
 #include <QSettings>
 #include <QFile>
 #include <QTextStream>
-#include <QPainter>
 
 #include "settings_defaults.h"
 
@@ -60,27 +59,6 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
     } else if (role == Qt::DecorationRole) {
         if (index.column() == Badges && !e.badges.isEmpty())
             return e.badges.first();
-        if (index.column() == Emotes && !e.emotes.isEmpty()) {
-            if (e.emotes.size() == 1)
-                return e.emotes.first();
-
-            int totalWidth = 0;
-            int maxHeight = 0;
-            for (const QPixmap &p : e.emotes) {
-                totalWidth += p.width();
-                maxHeight = qMax(maxHeight, p.height());
-            }
-
-            QPixmap combined(totalWidth, maxHeight);
-            combined.fill(Qt::transparent);
-            QPainter painter(&combined);
-            int x = 0;
-            for (const QPixmap &p : e.emotes) {
-                painter.drawPixmap(x, 0, p);
-                x += p.width();
-            }
-            return combined;
-        }
     } else if (role == Qt::ForegroundRole) {
         auto it = m_fgColors.find(e.command);
         if (it != m_fgColors.end())


### PR DESCRIPTION
## Summary
- Clip and manually paint emote sequences inside table cells via a custom delegate
- Remove default decoration data for the emote column to avoid overpainting
- Restore original CMake translation step order and deploy script argument

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a12bd6b76c83288a97d34e072f727a