### PR TITLE
Add message direction column to log viewer

### DIFF
--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -58,7 +58,7 @@
 #define CFG_LOG_COLUMNS "log/columns"
 #define CFG_LOG_COLOR_PREFIX "log/colors/"
 #define CFG_LOG_HIDE_CMDS "log/hide"
-#define DEFAULT_LOG_COLUMNS (QStringList() << "Timestamp" << "Command" << "Badges" << "Sender" << "Message" << "Tags" << "Emotes")
+#define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Timestamp" << "Command" << "Badges" << "Sender" << "Message" << "Tags" << "Emotes")
 #define DEFAULT_LOG_HIDE_CMDS (QStringList() << "PING" << "PONG")
 
 #define DEFAULT_VERSION 1 // So we can migrate from v1

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -1087,6 +1087,7 @@ void SetupWidget::loadLogSettings()
 {
     QSettings settings;
     QStringList cols = settings.value(CFG_LOG_COLUMNS, DEFAULT_LOG_COLUMNS).toStringList();
+    ui->chkDirection->setChecked(cols.contains("Direction"));
     ui->chkTimestamp->setChecked(cols.contains("Timestamp"));
     ui->chkCommand->setChecked(cols.contains("Command"));
     ui->chkBadges->setChecked(cols.contains("Badges"));
@@ -1165,6 +1166,7 @@ void SetupWidget::loadLogSettings()
             markDirty();
     });
 
+    connect(ui->chkDirection, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkTimestamp, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkCommand, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkBadges, &QCheckBox::checkStateChanged, this, markDirty);
@@ -1178,6 +1180,7 @@ void SetupWidget::saveLogSettings()
 {
     QSettings settings;
     QStringList cols;
+    if (ui->chkDirection->isChecked()) cols << "Direction";
     if (ui->chkTimestamp->isChecked()) cols << "Timestamp";
     if (ui->chkCommand->isChecked()) cols << "Command";
     if (ui->chkBadges->isChecked()) cols << "Badges";

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -944,6 +944,7 @@
           <string>Columns</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_cols">
+          <item><widget class="QCheckBox" name="chkDirection"><property name="text"><string>Direction</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkTimestamp"><property name="text"><string>Timestamp</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkCommand"><property name="text"><string>Command</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkBadges"><property name="text"><string>Badges</string></property></widget></item>

--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -58,13 +58,13 @@ void TwitchChatReader::onConnected()
     qDebug() << "Sending Commands";
     // Send required IRC commands
     m_webSocket->sendTextMessage(QStringLiteral("PASS oauth:") + m_token);
-    TwitchLogModel::instance()->addEntry("PASS", m_channel, QStringLiteral("oauth:***"), QString());
+    TwitchLogModel::instance()->addEntry(TwitchLogModel::Sent, "PASS", m_channel, QStringLiteral("oauth:***"), QString());
     m_webSocket->sendTextMessage(QStringLiteral("CAP REQ :twitch.tv/commands twitch.tv/tags twitch.tv/membership"));
-    TwitchLogModel::instance()->addEntry("CAP", m_channel, QStringLiteral("twitch.tv/commands twitch.tv/tags twitch.tv/membership"), QString());
+    TwitchLogModel::instance()->addEntry(TwitchLogModel::Sent, "CAP", m_channel, QStringLiteral("twitch.tv/commands twitch.tv/tags twitch.tv/membership"), QString());
     m_webSocket->sendTextMessage(QStringLiteral("NICK ") + m_channel);
-    TwitchLogModel::instance()->addEntry("NICK", m_channel, m_channel, QString());
+    TwitchLogModel::instance()->addEntry(TwitchLogModel::Sent, "NICK", m_channel, m_channel, QString());
     m_webSocket->sendTextMessage(QStringLiteral("JOIN #") + m_channel);
-    TwitchLogModel::instance()->addEntry("JOIN", m_channel, QStringLiteral("#") + m_channel, QString());
+    TwitchLogModel::instance()->addEntry(TwitchLogModel::Sent, "JOIN", m_channel, QStringLiteral("#") + m_channel, QString());
 }
 
 void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
@@ -102,13 +102,13 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
             QString response = message;
             response.replace("PING", "PONG");
             m_webSocket->sendTextMessage(response);
-            TwitchLogModel::instance()->addEntry("PING", sender, trailing, tags);
-            TwitchLogModel::instance()->addEntry("PONG", m_channel, trailing, QString());
+            TwitchLogModel::instance()->addEntry(TwitchLogModel::Received, "PING", sender, trailing, tags);
+            TwitchLogModel::instance()->addEntry(TwitchLogModel::Sent, "PONG", m_channel, trailing, QString());
             continue;
         }
 
         if (command != "PRIVMSG") {
-            TwitchLogModel::instance()->addEntry(command, sender, trailing, tags);
+            TwitchLogModel::instance()->addEntry(TwitchLogModel::Received, command, sender, trailing, tags);
             continue;
         }
 
@@ -199,7 +199,7 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
             emit emojiSent(slug, emojisFound[slug]);
         }
 
-        TwitchLogModel::instance()->addEntry(command, sender, trailing, metadata, QList<QPixmap>(), emotePixmaps);
+        TwitchLogModel::instance()->addEntry(TwitchLogModel::Received, command, sender, trailing, metadata, QList<QPixmap>(), emotePixmaps);
     }
 }
 

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -44,6 +44,8 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
 
     if (role == Qt::DisplayRole) {
         switch (index.column()) {
+        case Direction:
+            return e.direction == Sent ? QStringLiteral("➡️") : QStringLiteral("⬅️");
         case Timestamp:
             return e.timestamp.toString(Qt::ISODate);
         case Command:
@@ -97,6 +99,7 @@ QVariant TwitchLogModel::headerData(int section, Qt::Orientation orientation, in
 {
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
         switch (section) {
+        case Direction: return tr("Direction");
         case Timestamp: return tr("Timestamp");
         case Command: return tr("Command");
         case Badges: return tr("Badges");
@@ -109,7 +112,8 @@ QVariant TwitchLogModel::headerData(int section, Qt::Orientation orientation, in
     return QVariant();
 }
 
-void TwitchLogModel::addEntry(const QString &command,
+void TwitchLogModel::addEntry(MsgDirection direction,
+                              const QString &command,
                               const QString &sender,
                               const QString &message,
                               const QString &tags,
@@ -122,6 +126,7 @@ void TwitchLogModel::addEntry(const QString &command,
         return;
     beginInsertRows(QModelIndex(), m_entries.size(), m_entries.size());
     Entry e;
+    e.direction = direction;
     e.timestamp = QDateTime::currentDateTime();
     e.command = command;
     e.sender = sender;
@@ -140,7 +145,8 @@ bool TwitchLogModel::exportToFile(const QString &fileName) const
         return false;
     QTextStream ts(&f);
     for (const Entry &e : m_entries) {
-        ts << e.timestamp.toString(Qt::ISODate) << '\t'
+        ts << (e.direction == Sent ? QStringLiteral("➡️") : QStringLiteral("⬅️")) << '\t'
+           << e.timestamp.toString(Qt::ISODate) << '\t'
            << e.command << '\t'
            << e.sender << '\t'
            << e.message << '\t'

--- a/twitchlogmodel.h
+++ b/twitchlogmodel.h
@@ -11,9 +11,11 @@
 class TwitchLogModel : public QAbstractTableModel {
     Q_OBJECT
 public:
-    enum Columns { Timestamp = 0, Command, Badges, Sender, Message, Tags, Emotes, ColumnCount };
+    enum Columns { Direction = 0, Timestamp, Command, Badges, Sender, Message, Tags, Emotes, ColumnCount };
+    enum MsgDirection { Sent = 0, Received };
 
     struct Entry {
+        MsgDirection direction;
         QDateTime timestamp;
         QString command;
         QList<QPixmap> badges;
@@ -30,7 +32,8 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
-    void addEntry(const QString &command,
+    void addEntry(MsgDirection direction,
+                  const QString &command,
                   const QString &sender,
                   const QString &message,
                   const QString &tags,


### PR DESCRIPTION
## Summary
- show a new direction column with arrows for sent and received chat messages
- propagate message direction through TwitchChatReader into TwitchLogModel and log export
- expose the column in settings with default visibility

## Testing
- `cmake -S . -B build` *(fails: Cannot add target-level dependencies to non-existent target "atsumari")*


------
https://chatgpt.com/codex/tasks/task_e_68a0127f34788328bf3d49f8b8b41e12