### PR TITLE
Remove badges column

### DIFF
--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -58,7 +58,7 @@
 #define CFG_LOG_COLUMNS "log/columns"
 #define CFG_LOG_COLOR_PREFIX "log/colors/"
 #define CFG_LOG_HIDE_CMDS "log/hide"
-#define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Timestamp" << "Command" << "Badges" << "Sender" << "Message" << "Tags" << "Emotes")
+#define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Timestamp" << "Command" << "Sender" << "Message" << "Tags" << "Emotes")
 
 #define DEFAULT_LOG_COMMANDS (QStringList() << "001" << "002" << "003" << "004" << "353" << "366" << "372" << "375" << "376" \
                                        << "CAP" << "CLEARCHAT" << "CLEARMSG" << "GLOBALUSERSTATE" << "JOIN" << "NICK" << "NOTICE" \

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -1090,7 +1090,6 @@ void SetupWidget::loadLogSettings()
     ui->chkDirection->setChecked(cols.contains("Direction"));
     ui->chkTimestamp->setChecked(cols.contains("Timestamp"));
     ui->chkCommand->setChecked(cols.contains("Command"));
-    ui->chkBadges->setChecked(cols.contains("Badges"));
     ui->chkSender->setChecked(cols.contains("Sender"));
     ui->chkMessage->setChecked(cols.contains("Message"));
     ui->chkTags->setChecked(cols.contains("Tags"));
@@ -1162,7 +1161,6 @@ void SetupWidget::loadLogSettings()
     connect(ui->chkDirection, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkTimestamp, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkCommand, &QCheckBox::checkStateChanged, this, markDirty);
-    connect(ui->chkBadges, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkSender, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkMessage, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkTags, &QCheckBox::checkStateChanged, this, markDirty);
@@ -1176,7 +1174,6 @@ void SetupWidget::saveLogSettings()
     if (ui->chkDirection->isChecked()) cols << "Direction";
     if (ui->chkTimestamp->isChecked()) cols << "Timestamp";
     if (ui->chkCommand->isChecked()) cols << "Command";
-    if (ui->chkBadges->isChecked()) cols << "Badges";
     if (ui->chkSender->isChecked()) cols << "Sender";
     if (ui->chkMessage->isChecked()) cols << "Message";
     if (ui->chkTags->isChecked()) cols << "Tags";

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -947,7 +947,6 @@
           <item><widget class="QCheckBox" name="chkDirection"><property name="text"><string>Direction</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkTimestamp"><property name="text"><string>Timestamp</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkCommand"><property name="text"><string>Command</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkBadges"><property name="text"><string>Badges</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkSender"><property name="text"><string>Sender</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkMessage"><property name="text"><string>Message</string></property></widget></item>
           <item><widget class="QCheckBox" name="chkTags"><property name="text"><string>Tags</string></property></widget></item>

--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -213,7 +213,7 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
             }
         }
 
-        TwitchLogModel::instance()->addEntry(TwitchLogModel::Received, command, sender, trailing, metadata, QList<QPixmap>(), emotePixmaps, missingEmotes);
+        TwitchLogModel::instance()->addEntry(TwitchLogModel::Received, command, sender, trailing, metadata, emotePixmaps, missingEmotes);
     }
 }
 

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -59,9 +59,6 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
         default:
             return QVariant();
         }
-    } else if (role == Qt::DecorationRole) {
-        if (index.column() == Badges && !e.badges.isEmpty())
-            return e.badges.first();
     } else if (role == Qt::ForegroundRole) {
         auto it = m_fgColors.find(e.command);
         if (it != m_fgColors.end())
@@ -81,7 +78,6 @@ QVariant TwitchLogModel::headerData(int section, Qt::Orientation orientation, in
         case Direction: return tr("Direction");
         case Timestamp: return tr("Timestamp");
         case Command: return tr("Command");
-        case Badges: return tr("Badges");
         case Sender: return tr("Sender");
         case Message: return tr("Message");
         case Tags: return tr("Tags");
@@ -96,7 +92,6 @@ void TwitchLogModel::addEntry(MsgDirection direction,
                               const QString &sender,
                               const QString &message,
                               const QString &tags,
-                              const QList<QPixmap> &badges,
                               const QList<QPixmap> &emotes,
                               const QStringList &pendingEmotes)
 {
@@ -112,7 +107,6 @@ void TwitchLogModel::addEntry(MsgDirection direction,
     e.sender = sender;
     e.message = message;
     e.tags = tags;
-    e.badges = badges;
     e.emotes = emotes;
     e.pendingEmotes = pendingEmotes;
     m_entries.append(e);

--- a/twitchlogmodel.h
+++ b/twitchlogmodel.h
@@ -12,14 +12,13 @@
 class TwitchLogModel : public QAbstractTableModel {
     Q_OBJECT
 public:
-    enum Columns { Direction = 0, Timestamp, Command, Badges, Sender, Message, Tags, Emotes, ColumnCount };
+    enum Columns { Direction = 0, Timestamp, Command, Sender, Message, Tags, Emotes, ColumnCount };
     enum MsgDirection { Sent = 0, Received };
 
     struct Entry {
         MsgDirection direction;
         QDateTime timestamp;
         QString command;
-        QList<QPixmap> badges;
         QString sender;
         QString message;
         QString tags;
@@ -39,7 +38,6 @@ public:
                   const QString &sender,
                   const QString &message,
                   const QString &tags,
-                  const QList<QPixmap> &badges = QList<QPixmap>(),
                   const QList<QPixmap> &emotes = QList<QPixmap>(),
                   const QStringList &pendingEmotes = QStringList());
 


### PR DESCRIPTION
## Summary
- drop badges column from Twitch log model and UI
- update log settings defaults after removing badges

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" (Qt6Config.cmake))*

------
https://chatgpt.com/codex/tasks/task_e_68a1409af27483288c5165db5f5ffda4