### PR TITLE
Trim incoming messages to fix command coloring

### DIFF
--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -75,7 +75,7 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
         if (message.trimmed().isEmpty())
             continue;
 
-        QString msg = message;
+        QString msg = message.trimmed();
         QString tags;
         QString prefix;
         if (msg.startsWith("@")) {


### PR DESCRIPTION
## Summary
- Trim whitespace from incoming IRC messages before parsing so commands with no parameters (e.g., GLOBALUSERSTATE) are colorized properly in logs

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6Config.cmake)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_68a1401593108328bed823c9d135d45b