### PR TITLE
Use in-memory textures for emotes

### DIFF
--- a/emotewriter.cpp
+++ b/emotewriter.cpp
@@ -92,7 +92,7 @@ void EmoteWriter::saveEmoji(const QString &slug, const QString& emojiData)
     texData->setParent(this);
     texData->setSize(image.size());
     texData->setFormat(QQuick3DTextureData::RGBA8);
-    texData->setData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
+    texData->setTextureData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
 
     m_textures.insert(slug, texData);
     m_pixmaps.insert(slug, pixmap);
@@ -118,7 +118,7 @@ void EmoteWriter::handleNetworkReply(QNetworkReply *reply)
     texData->setParent(this);
     texData->setSize(img.size());
     texData->setFormat(QQuick3DTextureData::RGBA8);
-    texData->setData(QByteArray(reinterpret_cast<const char*>(img.constBits()), img.sizeInBytes()));
+    texData->setTextureData(QByteArray(reinterpret_cast<const char*>(img.constBits()), img.sizeInBytes()));
 
     QString key = isBig ? QStringLiteral("big_") + id : id;
     m_textures.insert(key, texData);

--- a/emotewriter.cpp
+++ b/emotewriter.cpp
@@ -88,8 +88,9 @@ void EmoteWriter::saveEmoji(const QString &slug, const QString& emojiData)
     painter.end();
 
     QImage image = pixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
-    auto *texData = new QQuick3DTextureData(this);
-    texData->setTextureSize(image.size());
+    auto *texData = new QQuick3DTextureData();
+    texData->setParent(this);
+    texData->setSize(image.size());
     texData->setFormat(QQuick3DTextureData::RGBA8);
     texData->setData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
 
@@ -113,8 +114,9 @@ void EmoteWriter::handleNetworkReply(QNetworkReply *reply)
     QPixmap pixmap = QPixmap::fromImage(image);
 
     QImage img = pixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
-    auto *texData = new QQuick3DTextureData(this);
-    texData->setTextureSize(img.size());
+    auto *texData = new QQuick3DTextureData();
+    texData->setParent(this);
+    texData->setSize(img.size());
     texData->setFormat(QQuick3DTextureData::RGBA8);
     texData->setData(QByteArray(reinterpret_cast<const char*>(img.constBits()), img.sizeInBytes()));
 

--- a/emotewriter.h
+++ b/emotewriter.h
@@ -22,8 +22,9 @@
 #include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-#include <QFile>
+#include <QPixmap>
 #include <QUrl>
+#include <QQuick3DTextureData>
 
 class EmoteWriter : public QObject {
     Q_OBJECT
@@ -33,17 +34,18 @@ public:
     void saveEmote(const QString &id);
     void saveBigEmote(const QString &id);
     void saveEmoji(const QString &slug, const QString &emojiData);
+    QPixmap pixmapFor(const QString &id) const;
 
 signals:
-    void emoteWritten(QString path);
-    void bigEmoteWritten(QString path);
+    void emoteReady(const QString &id, QQuick3DTextureData *textureData, const QPixmap &pixmap);
+    void bigEmoteReady(const QString &id, QQuick3DTextureData *textureData, const QPixmap &pixmap);
 
 private:
     void handleNetworkReply(QNetworkReply *reply);
 
     QNetworkAccessManager *networkManager;
-    QMap<QString, QString> m_emotes;
-    QMap<QString, QString> pendingEmotes; // To track emotes being downloaded
+    QMap<QString, QQuick3DTextureData*> m_textures;
+    QMap<QString, QPixmap> m_pixmaps;
 };
 
 

--- a/main.qml
+++ b/main.qml
@@ -137,10 +137,17 @@ Item {
 
     // Functions
 
-    function addEmote(emoteUrl, theta, phi, emoteSize) {
+    function addEmote(emoteSource, theta, phi, emoteSize) {
         // Add to QML scene for immediate visual feedback
         let radius = 50.02; // Default radius for chat emotes
         let opacity = 0.8; // Default opacity for chat emotes
+
+        var textureUrl = "";
+        var textureData = null;
+        if (typeof emoteSource === "string")
+            textureUrl = emoteSource;
+        else
+            textureData = emoteSource;
         
         // Handle random positioning (-1.0 means random position)
         let finalTheta = theta;
@@ -181,7 +188,8 @@ Item {
                         PrincipledMaterial {
                             alphaMode: PrincipledMaterial.Blend
                             baseColorMap: Texture {
-                                source: "` + emoteUrl + `"
+                                id: texMap
+                                source: "` + textureUrl + `"
                             }
                             cullMode: DefaultMaterial.NoCulling
                             opacity: ` + opacity + `
@@ -190,6 +198,9 @@ Item {
                 }
             }
         `, standAloneScene);
+
+        if (textureData !== null)
+            emote.children[0].materials[0].baseColorMap.textureData = textureData;
 
         emoteList.push(emote);
     }

--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -47,8 +47,6 @@
 #define CFG_CLIENT_ID "client_id"
 #define CFG_TOKEN "token"
 #define CFG_EXPIRY_TOKEN "expiry_token"
-#define CFG_EMOJI_DIR "dirs/emoji"
-#define CFG_EMOTE_DIR "dirs/emotes"
 #define CFG_EMOJI_FONT "emoji_font"
 #define CFG_LANGUAGE "language"
 #define CFG_PROFILES "profiles"
@@ -89,12 +87,8 @@
 #define DEFAULT_CLIENT_ID "3x2mzlmm9mz8qpml51m5mxc8dbdk4d"
 
 #ifdef Q_OS_WIN
-# define DEFAULT_EMOJI_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emojiInfo")
-# define DEFAULT_EMOTE_DIR QString("%1/%2").arg(qApp->applicationDirPath(), "emoteInfo")
 # define DEFAULT_EMOJI_FONT "Segoe UI Emoji"
 #else
-# define DEFAULT_EMOJI_DIR QString("%1/%2").arg(qEnvironmentVariable("HOME"), ".atsumari/emojiInfo")
-# define DEFAULT_EMOTE_DIR QString("%1/%2").arg(qEnvironmentVariable("HOME"), ".atsumari/emoteInfo")
 # define DEFAULT_EMOJI_FONT "Noto Color Emoji"
 #endif
 

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -349,7 +349,7 @@ void SetupWidget::runPreview()
         texData->setParent(m_previewRootItem);
         texData->setSize(image.size());
         texData->setFormat(QQuick3DTextureData::RGBA8);
-        texData->setData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
+        texData->setTextureData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
 
         QMetaObject::invokeMethod(m_previewRootItem, "addEmote", Qt::QueuedConnection,
                                 Q_ARG(QVariant, QVariant::fromValue(texData)),

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -28,7 +28,6 @@
 #include <QDesktopServices>
 #include <QMessageBox>
 #include <QStyleHints>
-#include <QFileInfo>
 #include <QMenu>
 #include <QCloseEvent>
 #include <QUrl>
@@ -226,20 +225,6 @@ SetupWidget::SetupWidget(QWidget *parent)
 
     setupPreview();
     runPreview();
-
-    // Directories tab
-    connect(ui->btnEmojiPath, &QPushButton::clicked, this, &SetupWidget::selectEmojiPath);
-    connect(ui->btnEmotePath, &QPushButton::clicked, this, &SetupWidget::selectEmotePath);
-    connect(ui->edtEmojiDir, &QLineEdit::textChanged, this, [=]() {
-        validatePaths(ui->edtEmojiDir);
-        m_shouldSave = true;
-        ui->btnSaveSettings->setEnabled(true);
-    });
-    connect(ui->edtEmoteDir, &QLineEdit::textChanged, this, [=]() {
-        validatePaths(ui->edtEmoteDir);
-        m_shouldSave = true;
-        ui->btnSaveSettings->setEnabled(true);
-    });
 
     // Twitch Tab
     connect(ui->btnAddExcludeChat, &QPushButton::clicked, this, &SetupWidget::addToExcludeList);
@@ -480,10 +465,6 @@ void SetupWidget::loadSettings()
     ui->lstExcludeChat->addItems(excludeChatList);
     ui->edtClientId->setText(settings.value(CFG_CLIENT_ID, DEFAULT_CLIENT_ID).toString());
 
-    // Directories
-    ui->edtEmojiDir->setText(settings.value(CFG_EMOJI_DIR, DEFAULT_EMOJI_DIR).toString());
-    ui->edtEmoteDir->setText(settings.value(CFG_EMOTE_DIR, DEFAULT_EMOTE_DIR).toString());
-
     loadLogSettings();
 }
 
@@ -532,10 +513,6 @@ void SetupWidget::saveSettings()
         QMessageBox::warning(this, tr("Changing default font"),
                              tr("Changing default font is not advised. SVG Based fonts may not work correctly on Windows, and non-SVG Based fonts may also fail to render correctly on other platforms"));
     }
-
-    // Directories
-    settings.setValue(CFG_EMOJI_DIR, ui->edtEmojiDir->text());
-    settings.setValue(CFG_EMOTE_DIR, ui->edtEmoteDir->text());
 
     // Twitch
     QStringList excludeChat;
@@ -638,16 +615,6 @@ void SetupWidget::openDevConsole()
     QDesktopServices::openUrl(QUrl("https://dev.twitch.tv/console"));
 }
 
-void SetupWidget::selectEmotePath()
-{
-    ui->edtEmoteDir->setText(QFileDialog::getExistingDirectory(this, tr("Select emotes directory"), ui->edtEmoteDir->text()));
-}
-
-void SetupWidget::selectEmojiPath()
-{
-    ui->edtEmojiDir->setText(QFileDialog::getExistingDirectory(this, tr("Select emojis directory"), ui->edtEmoteDir->text()));
-}
-
 void SetupWidget::resetAuth()
 {
     QSettings settings;
@@ -677,16 +644,13 @@ void SetupWidget::setIcons()
     ui->btnRemoveExcludeChat->setIcon(QIcon::fromTheme("list-remove"));
     ui->btnSaveSettings->setIcon(QIcon::fromTheme("document-save"));
     ui->btnClose->setIcon(QIcon::fromTheme("system-run"));
-    ui->btnEmojiPath->setIcon(QIcon::fromTheme("folder-open"));
-    ui->btnEmotePath->setIcon(QIcon::fromTheme("folder-open"));
     ui->btnDevConsole->setIcon(QIcon::fromTheme("applications-development"));
     ui->btnForceAuth->setIcon(QIcon::fromTheme("security-high"));
     ui->btnAboutQt->setIcon(QIcon::fromTheme("help-about"));
     ui->tabWidget->setTabIcon(0, QIcon::fromTheme("configure"));
-    ui->tabWidget->setTabIcon(1, QIcon::fromTheme("folder"));
-    ui->tabWidget->setTabIcon(2, QIcon::fromTheme("computer"));
-    ui->tabWidget->setTabIcon(3, QIcon::fromTheme("text-x-generic"));
-    ui->tabWidget->setTabIcon(4, QIcon::fromTheme("help-about"));
+    ui->tabWidget->setTabIcon(1, QIcon::fromTheme("computer"));
+    ui->tabWidget->setTabIcon(2, QIcon::fromTheme("text-x-generic"));
+    ui->tabWidget->setTabIcon(3, QIcon::fromTheme("help-about"));
 }
 
 void SetupWidget::populateLanguages()
@@ -747,27 +711,6 @@ void SetupWidget::setupPreview()
     
     // Get the root QML object for property updates
     m_previewRootItem = m_previewWindow->rootObject();
-}
-
-void SetupWidget::validatePaths(QLineEdit *edt)
-{
-    QString path = edt->text();
-
-    QFileInfo fi(path);
-
-    if (fi.isRelative()) {
-        edt->setStyleSheet("color: red");
-    } else {
-        if (fi.exists()) {
-            if (fi.isDir()) {
-                edt->setStyleSheet(QString());
-            } else {
-                edt->setStyleSheet("color: red");
-            }
-        } else {
-            edt->setStyleSheet("color: green");
-        }
-    }
 }
 
 void SetupWidget::newProfile()
@@ -1020,8 +963,6 @@ void SetupWidget::populateCurrentProfileControls()
 
 void SetupWidget::closeEvent(QCloseEvent *event)
 {
-    cleanupTempFiles();
-    
     if (m_shouldSave) {
         int ret = QMessageBox::question(this, tr("There are unsaved changes"),
                                         tr("Do you want to save changes before closing?"),
@@ -1040,18 +981,6 @@ void SetupWidget::closeEvent(QCloseEvent *event)
     }
 
     qGuiApp->quit();
-}
-
-void SetupWidget::cleanupTempFiles()
-{
-    QDir tempDir(QDir::tempPath());
-    QStringList filters;
-    filters << "atsumari_test_emoji_*.png";
-
-    QFileInfoList files = tempDir.entryInfoList(filters, QDir::Files);
-    for (const QFileInfo& file : files) {
-        QFile::remove(file.absoluteFilePath());
-    }
 }
 
 void SetupWidget::aboutQt()

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -345,8 +345,9 @@ void SetupWidget::runPreview()
         painter.end();
 
         QImage image = emojiPixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
-        auto *texData = new QQuick3DTextureData(m_previewRootItem);
-        texData->setTextureSize(image.size());
+        auto *texData = new QQuick3DTextureData();
+        texData->setParent(m_previewRootItem);
+        texData->setSize(image.size());
         texData->setFormat(QQuick3DTextureData::RGBA8);
         texData->setData(QByteArray(reinterpret_cast<const char*>(image.constBits()), image.sizeInBytes()));
 

--- a/setupwidget.h
+++ b/setupwidget.h
@@ -53,15 +53,12 @@ private:
     void resetDecoration();
     void selectDecoration();
     void openDevConsole();
-    void selectEmotePath();
-    void selectEmojiPath();
     void resetAuth();
     void setIcons();
     void populateLanguages();
     void populateMaterialTypes();
     void populateRefractionTypes();
     void setupPreview();
-    void validatePaths(QLineEdit* edt);
     void newProfile();
     void duplicateProfile();
     void renameProfile();
@@ -69,7 +66,6 @@ private:
     void createProfileMenus();
     void populateCurrentProfileControls();
     void closeEvent(QCloseEvent* event);
-    void cleanupTempFiles();
     void aboutQt();
     void loadLogSettings();
     void saveLogSettings();

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -728,60 +728,6 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabDirectories">
-      <attribute name="title">
-       <string>Directories</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="edtEmoteDir"/>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Emoji directory:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="btnEmojiPath">
-         <property name="text">
-          <string>Select Directory...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QPushButton" name="btnEmotePath">
-         <property name="text">
-          <string>Select Directory...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="edtEmojiDir"/>
-       </item>
-       <item row="2" column="0" colspan="3">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Twitch emote directory:</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
      <widget class="QWidget" name="tabTwitch">
       <attribute name="title">
        <string>Twitch</string>
@@ -944,13 +890,55 @@
           <string>Columns</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_cols">
-          <item><widget class="QCheckBox" name="chkDirection"><property name="text"><string>Direction</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkTimestamp"><property name="text"><string>Timestamp</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkCommand"><property name="text"><string>Command</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkSender"><property name="text"><string>Sender</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkMessage"><property name="text"><string>Message</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkTags"><property name="text"><string>Tags</string></property></widget></item>
-          <item><widget class="QCheckBox" name="chkEmotes"><property name="text"><string>Emotes</string></property></widget></item>
+          <item>
+           <widget class="QCheckBox" name="chkDirection">
+            <property name="text">
+             <string>Direction</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkTimestamp">
+            <property name="text">
+             <string>Timestamp</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkCommand">
+            <property name="text">
+             <string>Command</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkSender">
+            <property name="text">
+             <string>Sender</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkMessage">
+            <property name="text">
+             <string>Message</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkTags">
+            <property name="text">
+             <string>Tags</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="chkEmotes">
+            <property name="text">
+             <string>Emotes</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -1002,8 +990,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>933</width>
-            <height>605</height>
+            <width>935</width>
+            <height>611</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1205,10 +1193,6 @@
   <tabstop>btnSelectDecoration</tabstop>
   <tabstop>btnResetDecoration</tabstop>
   <tabstop>cboEmojiFont</tabstop>
-  <tabstop>edtEmojiDir</tabstop>
-  <tabstop>btnEmojiPath</tabstop>
-  <tabstop>edtEmoteDir</tabstop>
-  <tabstop>btnEmotePath</tabstop>
   <tabstop>edtExcludeChat</tabstop>
   <tabstop>btnAddExcludeChat</tabstop>
   <tabstop>lstExcludeChat</tabstop>

--- a/twitchchatreader.h
+++ b/twitchchatreader.h
@@ -24,10 +24,12 @@
 
 #include "emojimapper.h"
 
+class EmoteWriter;
+
 class TwitchChatReader : public QObject {
     Q_OBJECT
 public:
-    TwitchChatReader(const QString& url, const QString& token, const QString& channel, QObject* parent = nullptr);
+    TwitchChatReader(const QString& url, const QString& token, const QString& channel, EmoteWriter* emoteWriter, QObject* parent = nullptr);
     ~TwitchChatReader();
 
 signals:
@@ -45,6 +47,7 @@ private:
     QString m_channel;
 
     EmojiMapper m_emojiMapper;
+    EmoteWriter* m_emoteWriter;
 };
 
 #endif // TWITCHCHATREADER_H

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -3,7 +3,6 @@
 #include <QSettings>
 #include <QFile>
 #include <QTextStream>
-#include <QFileInfo>
 
 #include "settings_defaults.h"
 #include "logcommandcolors.h"
@@ -167,10 +166,8 @@ void TwitchLogModel::loadColors()
     }
 }
 
-void TwitchLogModel::loadEmote(const QString &path)
+void TwitchLogModel::loadEmote(const QString &id, const QPixmap &pix)
 {
-    QString id = QFileInfo(path).baseName();
-    QPixmap pix(path);
     if (pix.isNull())
         return;
     for (int i = 0; i < m_entries.size(); ++i) {

--- a/twitchlogmodel.h
+++ b/twitchlogmodel.h
@@ -46,7 +46,7 @@ public:
     QList<QPixmap> emotesForRow(int row) const;
 
 public slots:
-    void loadEmote(const QString &path);
+    void loadEmote(const QString &id, const QPixmap &pixmap);
 
 private:
     explicit TwitchLogModel(QObject *parent = nullptr);


### PR DESCRIPTION
## Summary
- create textures for emotes and emojis from memory and avoid temporary image files
- pass texture data through EmoteWriter to QML via `textureData`
- update chat reader, logs, and setup preview to consume in-memory pixmaps

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake qt6-config.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_68a2a6a3dc288328be789b69abf204ef