### PR TITLE
Add reset button for log command colors

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -699,6 +699,7 @@ void SetupWidget::setIcons()
     ui->btnSelectSpecular->setIcon(QIcon::fromTheme("color-picker"));
     ui->btnSelectAmbient->setIcon(QIcon::fromTheme("color-picker"));
     ui->btnSelectLight->setIcon(QIcon::fromTheme("color-picker"));
+    ui->btnResetCommandColors->setIcon(QIcon::fromTheme("edit-undo"));
     ui->btnResetDecoration->setIcon(QIcon::fromTheme("edit-undo"));
     ui->btnSelectDecoration->setIcon(QIcon::fromTheme("document-open"));
     ui->btnAddExcludeChat->setIcon(QIcon::fromTheme("list-add"));
@@ -1173,6 +1174,19 @@ void SetupWidget::loadLogSettings()
     connect(ui->chkMessage, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkTags, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkEmotes, &QCheckBox::checkStateChanged, this, markDirty);
+    connect(ui->btnResetCommandColors, &QPushButton::clicked, this, [=]() {
+        for (int r = 0; r < ui->tblCommandColors->rowCount(); ++r) {
+            QString cmd = ui->tblCommandColors->item(r,0)->text();
+            const auto defaults = defaultCommandColors(cmd);
+            QTableWidgetItem* fgItem = ui->tblCommandColors->item(r,2);
+            QTableWidgetItem* bgItem = ui->tblCommandColors->item(r,3);
+            fgItem->setForeground(defaults.first);
+            fgItem->setText(defaults.first.name());
+            bgItem->setBackground(defaults.second);
+            bgItem->setText(defaults.second.name());
+        }
+        markDirty();
+    });
 }
 
 void SetupWidget::saveLogSettings()

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -1000,17 +1000,24 @@
              </property>
             </column>
             <column>
-             <property name="text">
-              <string>Background</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+            <property name="text">
+             <string>Background</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnResetCommandColors">
+           <property name="text">
+            <string>Reset to default</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
      <widget class="QWidget" name="tabAbout">
       <attribute name="title">
        <string>About</string>


### PR DESCRIPTION
## Summary
- add UI button to restore default log foreground/background colors
- wire up button logic and icon

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT"...)*

------
https://chatgpt.com/codex/tasks/task_e_68a80885a5448328bebd02acbeaa0519