### PR TITLE
Open logs on tray icon double click

### DIFF
--- a/atsumarilauncher.cpp
+++ b/atsumarilauncher.cpp
@@ -209,6 +209,10 @@ void AtsumariLauncher::launch()
         QAction* quitAct = menu->addAction(tr("Quit"));
         QObject::connect(quitAct, &QAction::triggered, this, &QCoreApplication::quit);
         m_tray->setContextMenu(menu);
+        QObject::connect(m_tray, &QSystemTrayIcon::activated, this, [this](QSystemTrayIcon::ActivationReason reason) {
+            if (reason == QSystemTrayIcon::DoubleClick)
+                m_logDialog->show();
+        });
         m_tray->show();
     } else {
         m_container->setContextMenuPolicy(Qt::CustomContextMenu);


### PR DESCRIPTION
## Summary
- show log window when double-clicking the tray icon

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7af950dc8328b1a6b07c78cbc64f