### PR TITLE
Remove duplicate Qt includes

### DIFF
--- a/twitchauthflow.cpp
+++ b/twitchauthflow.cpp
@@ -27,9 +27,6 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDesktopServices>
-#include <QUrlQuery>
-#include <QJsonDocument>
-#include <QJsonObject>
 
 #include "settings_defaults.h"
 


### PR DESCRIPTION
## Summary
- tidy TwitchAuthFlow includes by removing duplicate Qt headers and maintaining project include order

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_68acf9487490832890aa9695ffad845a