### PR TITLE
Use automatic allocation for SetupWidget

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
 
     LocaleHelper::loadBestTranslation();
 
-    SetupWidget* setupw = new SetupWidget();
-    setupw->show();
+    SetupWidget setupw;
+    setupw.show();
 
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- replace SetupWidget pointer allocation with automatic object
- adjust subsequent usage to call show() directly

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "QT")*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf957a54c8328b0900ec80a76564d