### PR TITLE
Reuse ping timer and clean up on destruction

### DIFF
--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -54,6 +54,10 @@ TwitchChatReader::TwitchChatReader(const QString &url, const QString &token, con
 TwitchChatReader::~TwitchChatReader()
 {
     m_webSocket->close();
+    if (m_pingTimer) {
+        m_pingTimer->stop();
+        m_pingTimer->deleteLater();
+    }
 }
 
 void TwitchChatReader::onConnected()
@@ -213,9 +217,11 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
 
 void TwitchChatReader::startPingTimer()
 {
-    QTimer* pingTimer = new QTimer(this);
-    connect(pingTimer, &QTimer::timeout, this, [=]() {
-        m_webSocket->sendTextMessage("PING");
-    });
-    pingTimer->start(180000); // Send a PING every 3 minutes
+    if (!m_pingTimer) {
+        m_pingTimer = new QTimer(this);
+        connect(m_pingTimer, &QTimer::timeout, this, [=]() {
+            m_webSocket->sendTextMessage("PING");
+        });
+    }
+    m_pingTimer->start(180000); // Send a PING every 3 minutes
 }

--- a/twitchchatreader.h
+++ b/twitchchatreader.h
@@ -21,6 +21,7 @@
 #include <QCoreApplication>
 #include <QtWebSockets/QWebSocket>
 #include <QtCore/QUrl>
+#include <QTimer>
 
 #include "emojimapper.h"
 
@@ -45,6 +46,7 @@ private:
     QWebSocket* m_webSocket;
     QString m_token;
     QString m_channel;
+    QTimer* m_pingTimer = nullptr;
 
     EmojiMapper m_emojiMapper;
     EmoteWriter* m_emoteWriter;


### PR DESCRIPTION
## Summary
- Maintain a persistent ping timer for Twitch connections and reuse it instead of creating a new timer each call
- Safely stop and delete the ping timer when the reader is destroyed

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake, qt6-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68acf96ab9b4832881090211aca6659c