### PR TITLE
Remove redundant returns from translation loaders

### DIFF
--- a/localehelper.cpp
+++ b/localehelper.cpp
@@ -36,7 +36,6 @@ void LocaleHelper::loadBestTranslation(const QString &baseName, const QString &d
     if (result) {
         qApp->installTranslator(&translator);
     }
-    return;
 }
 
 void LocaleHelper::loadTranslation(const QLocale &locale, const QString &baseName, const QString &directory)
@@ -46,7 +45,6 @@ void LocaleHelper::loadTranslation(const QLocale &locale, const QString &baseNam
     if (result) {
         qApp->installTranslator(&translator);
     }
-    return;
 }
 
 QLocale LocaleHelper::findBestLocale(const QLocale &locale, const QString &baseName, const QString &directory)


### PR DESCRIPTION
## Summary
- Clean up translation loading functions by removing unnecessary `return` statements

## Testing
- `cmake --build build --target emojimapper_tests`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68acf976b6888328b2d19401524a4c22