### PR TITLE
Delete network reply on error

### DIFF
--- a/emotewriter.cpp
+++ b/emotewriter.cpp
@@ -102,8 +102,11 @@ void EmoteWriter::saveEmoji(const QString &slug, const QString& emojiData)
 
 void EmoteWriter::handleNetworkReply(QNetworkReply *reply)
 {
-    if (!reply || reply->error() != QNetworkReply::NoError)
+    if (!reply || reply->error() != QNetworkReply::NoError) {
+        if (reply)
+            reply->deleteLater();
         return;
+    }
 
     QString id = reply->property("emoteId").toString();
     bool isBig = reply->property("isBig").toBool();


### PR DESCRIPTION
## Summary
- ensure network replies are cleaned up on error in EmoteWriter

## Testing
- `cmake --build build --verbose -j1` *(fails: QtNetworkAuth/qoauth2deviceauthorizationflow.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acf950d91083289b82893bc231d8bd