### PR TITLE
Limit material spin boxes to normalized range

### DIFF
--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -156,16 +156,29 @@
                       <property name="tickInterval">
                        <number>10</number>
                       </property>
+                    </widget>
+                   </item>
+                   <item>
+                     <widget class="QDoubleSpinBox" name="spnGlossiness">
+                      <property name="minimum">
+                       <double>0.000000000000000</double>
+                      </property>
+                      <property name="maximum">
+                       <double>1.000000000000000</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.010000000000000</double>
+                      </property>
+                      <property name="decimals">
+                       <number>2</number>
+                      </property>
                      </widget>
-                    </item>
-                    <item>
-                     <widget class="QDoubleSpinBox" name="spnGlossiness"/>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+              </item>
                <item row="2" column="1">
                 <layout class="QHBoxLayout" name="horizontalLayout_17">
                  <item>
@@ -337,15 +350,28 @@
                       <property name="tickInterval">
                        <number>10</number>
                       </property>
+                    </widget>
+                   </item>
+                   <item>
+                     <widget class="QDoubleSpinBox" name="spnRoughness">
+                      <property name="minimum">
+                       <double>0.000000000000000</double>
+                      </property>
+                      <property name="maximum">
+                       <double>1.000000000000000</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.010000000000000</double>
+                      </property>
+                      <property name="decimals">
+                       <number>2</number>
+                      </property>
                      </widget>
-                    </item>
-                    <item>
-                     <widget class="QDoubleSpinBox" name="spnRoughness"/>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="1" column="1">
-                   <layout class="QHBoxLayout" name="horizontalLayout_18">
+                   </item>
+                  </layout>
+                 </item>
+                 <item row="1" column="1">
+                  <layout class="QHBoxLayout" name="horizontalLayout_18">
                     <item>
                      <widget class="QSlider" name="sldMetalness">
                       <property name="maximum">
@@ -368,15 +394,28 @@
                       </property>
                       <property name="tickInterval">
                        <number>10</number>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                     <widget class="QDoubleSpinBox" name="spnMetalness">
+                      <property name="minimum">
+                       <double>0.000000000000000</double>
+                      </property>
+                      <property name="maximum">
+                       <double>1.000000000000000</double>
+                      </property>
+                      <property name="singleStep">
+                       <double>0.010000000000000</double>
+                      </property>
+                      <property name="decimals">
+                       <number>2</number>
                       </property>
                      </widget>
-                    </item>
-                    <item>
-                     <widget class="QDoubleSpinBox" name="spnMetalness"/>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="2" column="1">
+                   </item>
+                  </layout>
+                 </item>
+                 <item row="2" column="1">
                    <layout class="QHBoxLayout" name="horizontalLayout_19">
                     <item>
                      <widget class="QComboBox" name="cboRefraction"/>
@@ -520,16 +559,29 @@
                    </property>
                    <property name="tickInterval">
                     <number>10</number>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QDoubleSpinBox" name="spnLightBrightness"/>
-                 </item>
-                </layout>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label">
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QDoubleSpinBox" name="spnLightBrightness">
+                  <property name="minimum">
+                   <double>0.000000000000000</double>
+                  </property>
+                  <property name="maximum">
+                   <double>1.000000000000000</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                  <property name="decimals">
+                   <number>2</number>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="13" column="0">
+               <widget class="QLabel" name="label">
                  <property name="text">
                   <string>Emoji Font:</string>
                  </property>


### PR DESCRIPTION
## Summary
- Constrain glossiness, roughness, metalness, and light brightness spin boxes to 0–1 with 0.01 steps and two decimals

## Testing
- `cmake ..`
- `cmake --build .` *(fails: QtNetworkAuth/qoauth2deviceauthorizationflow.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acfa6f5d348328b2da5d2ba57aea67