### PR TITLE
Fix spin box property setters

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -206,7 +206,7 @@ SetupWidget::SetupWidget(QWidget *parent)
     });
 
     connect(ui->spnLightBrightness, &QDoubleSpinBox::valueChanged, this, [=]() {
-        m_profiles[m_currentProfile]->setRefraction(ui->spnLightBrightness->value() * 100);
+        m_profiles[m_currentProfile]->setLightBrightness(ui->spnLightBrightness->value() * 100);
         ui->sldLightBrightness->setValue(ui->spnLightBrightness->value() * 100);
         m_shouldSave = true;
         ui->btnSaveSettings->setEnabled(true);
@@ -222,7 +222,7 @@ SetupWidget::SetupWidget(QWidget *parent)
     });
 
     connect(ui->spnGlossiness, &QDoubleSpinBox::valueChanged, this, [=]() {
-        m_profiles[m_currentProfile]->setRefraction(ui->spnGlossiness->value() * 100);
+        m_profiles[m_currentProfile]->setGlossiness(ui->spnGlossiness->value() * 100);
         ui->sldGlossiness->setValue(ui->spnGlossiness->value() * 100);
         m_shouldSave = true;
         ui->btnSaveSettings->setEnabled(true);


### PR DESCRIPTION
## Summary
- update light brightness spin box to set light brightness property
- update glossiness spin box to set glossiness property

## Testing
- `cmake ..`
- `cmake --build . --parallel` *(fails: missing QtNetworkAuth/QWebSocket features in installed Qt 6.4)*
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68acfa7f9d6c8328a0054ff91d1d506c