### PR TITLE
Clear profile pointers in SetupWidget destructor

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -20,6 +20,7 @@
 #include "./ui_setupwidget.h"
 
 #include <algorithm>
+#include <QtAlgorithms>
 
 #include <QSettings>
 #include <QColorDialog>
@@ -324,6 +325,9 @@ SetupWidget::SetupWidget(QWidget *parent)
 
 SetupWidget::~SetupWidget()
 {
+    qDeleteAll(m_profiles);
+    m_profiles.clear();
+
     delete ui;
     if (m_previewWindow) m_previewWindow->deleteLater();
 }


### PR DESCRIPTION
## Summary
- ensure SetupWidget cleans up profile pointers and resets the container

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: fatal error: QtNetworkAuth/qoauth2deviceauthorizationflow.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acfef588308328a8f7b3188c6a3375