### PR TITLE
Handle failed image load in EmoteWriter

### DIFF
--- a/emotewriter.cpp
+++ b/emotewriter.cpp
@@ -25,6 +25,7 @@
 #include <QFontDatabase>
 #include <QSettings>
 #include <QImage>
+#include <QDebug>
 
 #include "settings_defaults.h"
 
@@ -113,7 +114,11 @@ void EmoteWriter::handleNetworkReply(QNetworkReply *reply)
 
     QByteArray data = reply->readAll();
     QImage image;
-    image.loadFromData(data);
+    if (!image.loadFromData(data)) {
+        qWarning() << "Failed to load emote image for id" << id;
+        reply->deleteLater();
+        return;
+    }
     QPixmap pixmap = QPixmap::fromImage(image);
 
     QImage img = pixmap.toImage().convertToFormat(QImage::Format_RGBA8888);


### PR DESCRIPTION
## Summary
- Ensure network emote images load successfully before creating textures
- Log a warning and skip texture creation when image data is invalid

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: QtNetworkAuth/qoauth2deviceauthorizationflow.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68acfefa74688328b8bb947fc167a313