### PR TITLE
Normalize excluded chat names to lowercase

### DIFF
--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -126,6 +126,9 @@ void TwitchChatReader::onTextMessageReceived(const QString &allMsgs)
         if (nameMatch.hasMatch()) {
             QSettings settings;
             QStringList exceptNames = settings.value(CFG_EXCLUDE_CHAT).toStringList();
+            for (QString &exceptName : exceptNames) {
+                exceptName = exceptName.toLower();
+            }
             QString nameData = nameMatch.captured(1).toLower();
             if (exceptNames.contains(nameData)) {
                 continue;


### PR DESCRIPTION
## Summary
- Convert excluded chat usernames to lowercase for case-insensitive filtering

## Testing
- `cmake -S . -B build` (fails: Could not find Qt6Config.cmake)
- `ctest --test-dir build` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68acff09b6d88328ab8ec6c63443eee9