### PR TITLE
Remove unused state param from TwitchAuthFlow

### DIFF
--- a/atsumarilauncher.cpp
+++ b/atsumarilauncher.cpp
@@ -20,7 +20,6 @@
 #include <QQuickView>
 #include <QQuickItem>
 #include <QUrl>
-#include <QRandomGenerator64>
 #include <QSettings>
 #include <QVBoxLayout>
 #include <QGuiApplication>
@@ -40,7 +39,7 @@
 
 AtsumariLauncher::AtsumariLauncher(QObject *parent)
     : QObject(parent)
-    , m_twFlow(new TwitchAuthFlow(QString("a123%1").arg(QRandomGenerator64::global()->generate())))
+    , m_twFlow(new TwitchAuthFlow(this))
     , m_emw(new EmoteWriter())
     , m_tReader(nullptr)
     , m_mw(new QMainWindow)

--- a/twitchauthflow.cpp
+++ b/twitchauthflow.cpp
@@ -30,7 +30,7 @@
 
 #include "settings_defaults.h"
 
-TwitchAuthFlow::TwitchAuthFlow(const QString& state, QObject *parent)
+TwitchAuthFlow::TwitchAuthFlow(QObject *parent)
     : QObject{parent}
     , m_token(QString())
     , m_authInProgress(false)
@@ -90,9 +90,6 @@ void TwitchAuthFlow::requestTokenValidation()
         onValidateReply(reply);
     });
 }
-
-// parseToken function removed - no longer needed with external browser approach
-
 void TwitchAuthFlow::requestUserinfo()
 {
     QSettings settings;

--- a/twitchauthflow.h
+++ b/twitchauthflow.h
@@ -27,7 +27,7 @@
 class TwitchAuthFlow : public QObject {
     Q_OBJECT
 public:
-    explicit TwitchAuthFlow(const QString& state, QObject *parent = nullptr);
+    explicit TwitchAuthFlow(QObject *parent = nullptr);
     ~TwitchAuthFlow();
     QString token() const;
 
@@ -37,7 +37,6 @@ signals:
     void loginFetched(QString login);
 
 private:
-    void parseToken(QUrl newUrl);
     void requestUserinfo();
     void onUserinfoReply(QNetworkReply* reply);
     void requestTokenValidation();


### PR DESCRIPTION
## Summary
- drop obsolete state argument from TwitchAuthFlow constructor
- remove legacy parseToken declaration
- update launcher to use new TwitchAuthFlow signature

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68acff2e7f4c8328821939076c87e4bf