### PR TITLE
Check for new releases on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Quick3D WebSockets NetworkAuth Gui LinguistTools Test)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Quick3D WebSockets NetworkAuth Gui LinguistTools Test)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core Widgets Quick3D WebSockets Network NetworkAuth Gui LinguistTools Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets Quick3D WebSockets Network NetworkAuth Gui LinguistTools Test)
 
 qt_standard_project_setup(I18N_TRANSLATED_LANGUAGES pt_BR)
 
@@ -77,9 +77,12 @@ target_link_libraries(atsumari PRIVATE
     Qt${QT_VERSION_MAJOR}::Widgets
     Qt${QT_VERSION_MAJOR}::Quick3D
     Qt${QT_VERSION_MAJOR}::WebSockets
+    Qt${QT_VERSION_MAJOR}::Network
     Qt${QT_VERSION_MAJOR}::NetworkAuth
     Qt${QT_VERSION_MAJOR}::Gui
 )
+
+target_compile_definitions(atsumari PRIVATE ATSUMARI_VERSION="${PROJECT_VERSION}")
 
 set_target_properties(atsumari PROPERTIES
     ${BUNDLE_ID_OPTION}

--- a/main.cpp
+++ b/main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
     QApplication::setOrganizationName("Push X!");
     QApplication::setApplicationName("Atsumari");
+    QApplication::setApplicationVersion(QStringLiteral(ATSUMARI_VERSION));
     app.setQuitOnLastWindowClosed(false);
 
     LocaleHelper::loadBestTranslation();

--- a/setupwidget.h
+++ b/setupwidget.h
@@ -60,6 +60,7 @@ private:
     void populateMaterialTypes();
     void populateRefractionTypes();
     void setupPreview();
+    void checkForUpdates();
     void newProfile();
     void duplicateProfile();
     void renameProfile();


### PR DESCRIPTION
## Summary
- check GitHub for newer releases on launch and offer to open the download page
- expose build version to the application
- link Qt Network library and embed version macro

## Testing
- `cmake -S . -B build` *(fails: Could NOT find XKB)*
- `cmake --build build` *(fails: QtNetworkAuth header missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b53862308328acf2bde6d72accd1