### PR TITLE
Add optional base texture

### DIFF
--- a/atsumarilauncher.cpp
+++ b/atsumarilauncher.cpp
@@ -90,6 +90,7 @@ void AtsumariLauncher::launch()
     
     // Load settings from current profile
     QString baseColor = settings.value(CFG_COLORS_BASE, DEFAULT_COLORS_BASE).toString();
+    QString baseTexture = settings.value(CFG_BASE_TEXTURE, DEFAULT_BASE_TEXTURE).toString();
     QString ambientColor = settings.value(CFG_COLORS_AMBIENT, DEFAULT_COLORS_AMBIENT).toString();
     QString specularColor = settings.value(CFG_COLORS_SPECULAR, DEFAULT_COLORS_SPECULAR).toString();
     QString lightColor = settings.value(CFG_COLORS_LIGHT, DEFAULT_COLORS_LIGHT).toString();
@@ -106,6 +107,10 @@ void AtsumariLauncher::launch()
     
     // Set QML properties based on settings
     rootItem->setProperty("baseColor", QColor(baseColor));
+    if (baseTexture.startsWith(":/"))
+        rootItem->setProperty("baseColorTexture", QString("qrc") + baseTexture);
+    else if (!baseTexture.isEmpty())
+        rootItem->setProperty("baseColorTexture", QUrl::fromLocalFile(baseTexture).toString());
     rootItem->setProperty("ambientColor", QColor(ambientColor));
     rootItem->setProperty("lightColor", QColor(lightColor));
     rootItem->setProperty("brightness", lightBrightness / 100.0);

--- a/i18n/atsumari_pt_BR.ts
+++ b/i18n/atsumari_pt_BR.ts
@@ -196,6 +196,11 @@
         <translation>Cor Base:</translation>
     </message>
     <message>
+        <location filename="../setupwidget.ui" line="632"/>
+        <source>Base Texture:</source>
+        <translation>Textura Base:</translation>
+    </message>
+    <message>
         <location filename="../setupwidget.ui" line="580"/>
         <source>Profile:</source>
         <translation>Perfil:</translation>
@@ -507,6 +512,11 @@ Clique com o botão direito em cada caixa de texto para utilizar as predefiniç�
         <location filename="../setupwidget.cpp" line="685"/>
         <source>Image Files (*.svg *.png *.jpg *.bmp)</source>
         <translation>Arquivos de Imagem (*.svg *.png *.jpg *.bmp)</translation>
+    </message>
+    <message>
+        <location filename="../setupwidget.cpp" line="466"/>
+        <source>Select base texture file</source>
+        <translation>Selecionar arquivo de textura base</translation>
     </message>
     <message>
         <source>Image Files (*.png *.jpg *.bmp)</source>

--- a/main.qml
+++ b/main.qml
@@ -10,6 +10,7 @@ Item {
 
     // Common Props
     property color baseColor: Qt.rgba(0.352, 0.27, 0.517, 1.0)
+    property url baseColorTexture: ""
     property color ambientColor: Qt.rgba(0.0, 0.0, 0.156, 1.0)
     property int rotationInterval: 3000
     property color lightColor: Qt.rgba(1.0, 1.0, 1.0, 1.0)
@@ -33,14 +34,21 @@ Item {
     property string decorationPath: "qrc:/decoration/kata_deco.png"
 
     property var cameraRotationTarget: Qt.vector3d(180, 360, 0)
+    Texture {
+        id: baseColorTex
+        source: root.baseColorTexture
+    }
+
     property var specMaterial: SpecularGlossyMaterial {
         albedoColor: root.baseColor
+        albedoMap: root.baseColorTexture === "" ? null : baseColorTex
         specularColor: root.specularColor
         glossiness: root.glossiness
     }
 
     property var princMaterial: PrincipledMaterial {
         baseColor: root.baseColor
+        baseColorMap: root.baseColorTexture === "" ? null : baseColorTex
         roughness: root.roughness
         metalness: root.metalness
         indexOfRefraction: root.refraction

--- a/profiledata.cpp
+++ b/profiledata.cpp
@@ -39,6 +39,16 @@ void ProfileData::setBaseColor(const QString &newBaseColor)
     m_baseColor = newBaseColor;
 }
 
+QString ProfileData::baseTexture() const
+{
+    return m_baseTexture;
+}
+
+void ProfileData::setBaseTexture(const QString &newBaseTexture)
+{
+    m_baseTexture = newBaseTexture;
+}
+
 QString ProfileData::specularColor() const
 {
     return m_specularColor;

--- a/profiledata.h
+++ b/profiledata.h
@@ -31,6 +31,8 @@ public:
     void setProfileName(const QString &newProfileName);
     QString baseColor() const;
     void setBaseColor(const QString &newBaseColor);
+    QString baseTexture() const;
+    void setBaseTexture(const QString &newBaseTexture);
     QString specularColor() const;
     void setSpecularColor(const QString &newSpecularColor);
     QString ambientColor() const;
@@ -69,6 +71,7 @@ public:
 private:
     QString m_profileName;
     QString m_baseColor;
+    QString m_baseTexture;
     QString m_ambientColor;
     QString m_lightColor;
     MaterialType m_materialType;

--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -30,6 +30,7 @@
 
 // v2
 #define CFG_COLORS_BASE "colors/base"
+#define CFG_BASE_TEXTURE "base_texture"
 #define CFG_MATERIAL_TYPE "material"
 #define CFG_LIGHT_BRIGHTNESS "light_brightness"
 #define CFG_ROUGHNESS "roughness"
@@ -74,6 +75,7 @@
 
 #define DEFAULT_MATERIAL_TYPE MaterialType::SpecularGlossy
 #define DEFAULT_COLORS_BASE "#5a4584"
+#define DEFAULT_BASE_TEXTURE ""
 #define DEFAULT_COLORS_SPECULAR "#5a4584"
 #define DEFAULT_COLORS_AMBIENT "#000000"
 #define DEFAULT_COLORS_LIGHT "#ffffff"

--- a/setupwidget.h
+++ b/setupwidget.h
@@ -53,6 +53,8 @@ private:
     void runPreview();
     void resetDecoration();
     void selectDecoration();
+    void resetBaseTexture();
+    void selectBaseTexture();
     void openDevConsole();
     void resetAuth();
     void setIcons();

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -617,16 +617,60 @@
                 </widget>
                </item>
                <item row="12" column="0">
-                <widget class="QLabel" name="lblLightColor_2">
-                 <property name="locale">
-                  <locale language="English" country="UnitedStates"/>
-                 </property>
-                 <property name="text">
-                  <string>Initial Decoration:</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
+               <widget class="QLabel" name="lblLightColor_2">
+                <property name="locale">
+                 <locale language="English" country="UnitedStates"/>
+                </property>
+                <property name="text">
+                 <string>Initial Decoration:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="0">
+               <widget class="QLabel" name="lblBaseTextureLabel">
+                <property name="text">
+                 <string>Base Texture:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="1">
+               <layout class="QHBoxLayout" name="horizontalLayout_baseTexture">
+                <item>
+                 <widget class="QLabel" name="lblBaseTexture">
+                  <property name="minimumSize">
+                   <size>
+                    <width>64</width>
+                    <height>64</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>64</width>
+                    <height>64</height>
+                   </size>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnSelectBaseTexture">
+                  <property name="text">
+                   <string>Select file...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnResetBaseTexture">
+                  <property name="text">
+                   <string>Reset to default</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="2" column="0">
                 <widget class="QLabel" name="label_7">
                  <property name="text">
                   <string>Profile:</string>
@@ -1331,6 +1375,8 @@ Right click on each text box to use shader presets.</string>
   <tabstop>spnIteration</tabstop>
   <tabstop>btnSelectDecoration</tabstop>
   <tabstop>btnResetDecoration</tabstop>
+  <tabstop>btnSelectBaseTexture</tabstop>
+  <tabstop>btnResetBaseTexture</tabstop>
   <tabstop>cboEmojiFont</tabstop>
   <tabstop>edtExcludeChat</tabstop>
   <tabstop>btnAddExcludeChat</tabstop>


### PR DESCRIPTION
## Summary
- Allow specifying a texture to drive material base color
- Persist and preview base texture settings
- Localize new base texture controls

## Testing
- `cmake ..` *(fails: Could NOT find XKB... but configuration completed)*
- `make -j$(nproc)` *(fails: QtNetworkAuth/qoauth2deviceauthorizationflow.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bfa45cec8328ab8163568af00479