### PR TITLE
Add Source column with IRC/EventSub emoji indicators to log view

### DIFF
--- a/logviewdialog.cpp
+++ b/logviewdialog.cpp
@@ -46,14 +46,17 @@ void LogViewDialog::applyColumnVisibility()
 {
     QSettings settings;
     QStringList cols = settings.value(CFG_LOG_COLUMNS, DEFAULT_LOG_COLUMNS).toStringList();
+    if (!settings.value(CFG_LOG_SOURCE_MIGRATED, false).toBool()) {
+        if (!cols.contains(QStringLiteral("Source")))
+            cols << QStringLiteral("Source");
+        settings.setValue(CFG_LOG_COLUMNS, cols);
+        settings.setValue(CFG_LOG_SOURCE_MIGRATED, true);
+    }
+
     QStringList translated;
     for (const QString &c : cols)
         translated << QCoreApplication::translate("TwitchLogModel", c.toUtf8().constData());
     for (int i = 0; i < TwitchLogModel::ColumnCount; ++i) {
-        if (i == TwitchLogModel::Source) {
-            m_table->setColumnHidden(i, false);
-            continue;
-        }
         QString name = TwitchLogModel::instance()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
         m_table->setColumnHidden(i, !translated.contains(name));
     }

--- a/logviewdialog.cpp
+++ b/logviewdialog.cpp
@@ -50,6 +50,10 @@ void LogViewDialog::applyColumnVisibility()
     for (const QString &c : cols)
         translated << QCoreApplication::translate("TwitchLogModel", c.toUtf8().constData());
     for (int i = 0; i < TwitchLogModel::ColumnCount; ++i) {
+        if (i == TwitchLogModel::Source) {
+            m_table->setColumnHidden(i, false);
+            continue;
+        }
         QString name = TwitchLogModel::instance()->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString();
         m_table->setColumnHidden(i, !translated.contains(name));
     }

--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -64,7 +64,7 @@
 #define CFG_LOG_AUTOSAVE_PERIOD_MIN "log/autosave/period_minutes"
 #define CFG_LOG_AUTOSAVE_DIRECTORY "log/autosave/directory"
 #define CFG_LOG_AUTOSAVE_NAME_PATTERN "log/autosave/name_pattern"
-#define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Timestamp" << "Command" << "Sender" << "Message" << "Tags" << "Emotes")
+#define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Source" << "Timestamp" << "Command" << "Sender" << "Message" << "Tags" << "Emotes")
 #define DEFAULT_LOG_AUTOSAVE_ENABLED false
 #define DEFAULT_LOG_AUTOSAVE_PERIOD_MIN 5
 #define DEFAULT_LOG_AUTOSAVE_DIRECTORY ""

--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -58,6 +58,7 @@
 #define CFG_CURRENT_PROFILE "current_profile"
 
 #define CFG_LOG_COLUMNS "log/columns"
+#define CFG_LOG_SOURCE_MIGRATED "log/source_migrated"
 #define CFG_LOG_COLOR_PREFIX "log/colors/"
 #define CFG_LOG_HIDE_CMDS "log/hide"
 #define CFG_LOG_AUTOSAVE_ENABLED "log/autosave/enabled"

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -1283,7 +1283,15 @@ void SetupWidget::loadLogSettings()
 {
     QSettings settings;
     QStringList cols = settings.value(CFG_LOG_COLUMNS, DEFAULT_LOG_COLUMNS).toStringList();
+    if (!settings.value(CFG_LOG_SOURCE_MIGRATED, false).toBool()) {
+        if (!cols.contains("Source"))
+            cols << "Source";
+        settings.setValue(CFG_LOG_COLUMNS, cols);
+        settings.setValue(CFG_LOG_SOURCE_MIGRATED, true);
+    }
+
     ui->chkDirection->setChecked(cols.contains("Direction"));
+    ui->chkSource->setChecked(cols.contains("Source"));
     ui->chkTimestamp->setChecked(cols.contains("Timestamp"));
     ui->chkCommand->setChecked(cols.contains("Command"));
     ui->chkSender->setChecked(cols.contains("Sender"));
@@ -1373,6 +1381,7 @@ void SetupWidget::loadLogSettings()
     });
 
     connect(ui->chkDirection, &QCheckBox::checkStateChanged, this, markDirty);
+    connect(ui->chkSource, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkTimestamp, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkCommand, &QCheckBox::checkStateChanged, this, markDirty);
     connect(ui->chkSender, &QCheckBox::checkStateChanged, this, markDirty);
@@ -1419,6 +1428,7 @@ void SetupWidget::saveLogSettings()
     QSettings settings;
     QStringList cols;
     if (ui->chkDirection->isChecked()) cols << "Direction";
+    if (ui->chkSource->isChecked()) cols << "Source";
     if (ui->chkTimestamp->isChecked()) cols << "Timestamp";
     if (ui->chkCommand->isChecked()) cols << "Command";
     if (ui->chkSender->isChecked()) cols << "Sender";
@@ -1426,6 +1436,7 @@ void SetupWidget::saveLogSettings()
     if (ui->chkTags->isChecked()) cols << "Tags";
     if (ui->chkEmotes->isChecked()) cols << "Emotes";
     settings.setValue(CFG_LOG_COLUMNS, cols);
+    settings.setValue(CFG_LOG_SOURCE_MIGRATED, true);
 
     settings.beginGroup("log/colors");
     settings.remove("");

--- a/setupwidget.ui
+++ b/setupwidget.ui
@@ -1102,6 +1102,13 @@ Right click on each text box to use shader presets.</string>
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="chkSource">
+            <property name="text">
+             <string>Source</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="chkTimestamp">
             <property name="text">
              <string>Timestamp</string>
@@ -1465,6 +1472,7 @@ Right click on each text box to use shader presets.</string>
   <tabstop>btnDevConsole</tabstop>
   <tabstop>btnForceAuth</tabstop>
   <tabstop>chkDirection</tabstop>
+  <tabstop>chkSource</tabstop>
   <tabstop>chkTimestamp</tabstop>
   <tabstop>chkCommand</tabstop>
   <tabstop>chkSender</tabstop>

--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -530,6 +530,8 @@ void TwitchChatReader::processEvent(ChatEvent &event)
                                          event.sender,
                                          event.trailing,
                                          event.metadata,
+                                         event.fromIrc,
+                                         event.fromEventSub,
                                          emotePixmaps,
                                          missingEmotes);
 }

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -48,6 +48,12 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
         switch (index.column()) {
         case Direction:
             return e.direction == Sent ? QStringLiteral("➡️") : QStringLiteral("⬅️");
+        case Source:
+            if (e.fromIrc && e.fromEventSub)
+                return QStringLiteral("📝🧩");
+            if (e.fromEventSub)
+                return QStringLiteral("🧩");
+            return QStringLiteral("📝");
         case Timestamp:
             return e.timestamp.toString(Qt::ISODate);
         case Command:
@@ -60,6 +66,14 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
             return e.tags;
         default:
             return QVariant();
+        }
+    } else if (role == Qt::ToolTipRole) {
+        if (index.column() == Source) {
+            if (e.fromIrc && e.fromEventSub)
+                return tr("Origin: IRC and EventSub");
+            if (e.fromEventSub)
+                return tr("Origin: EventSub");
+            return tr("Origin: IRC");
         }
     } else if (role == Qt::ForegroundRole) {
         auto it = m_fgColors.find(e.command);
@@ -78,6 +92,7 @@ QVariant TwitchLogModel::headerData(int section, Qt::Orientation orientation, in
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
         switch (section) {
         case Direction: return tr("Direction");
+        case Source: return tr("Source");
         case Timestamp: return tr("Timestamp");
         case Command: return tr("Command");
         case Sender: return tr("Sender");
@@ -94,6 +109,8 @@ void TwitchLogModel::addEntry(MsgDirection direction,
                               const QString &sender,
                               const QString &message,
                               const QString &tags,
+                              bool fromIrc,
+                              bool fromEventSub,
                               const QList<QPixmap> &emotes,
                               const QStringList &pendingEmotes)
 {
@@ -109,6 +126,8 @@ void TwitchLogModel::addEntry(MsgDirection direction,
     e.sender = sender;
     e.message = message;
     e.tags = tags;
+    e.fromIrc = fromIrc;
+    e.fromEventSub = fromEventSub;
     e.emotes = emotes;
     e.pendingEmotes = pendingEmotes;
     m_entries.append(e);
@@ -125,6 +144,7 @@ bool TwitchLogModel::exportToFile(const QString &fileName) const
     QTextStream ts(&f);
     for (const Entry &e : m_entries) {
         ts << (e.direction == Sent ? QStringLiteral("➡️") : QStringLiteral("⬅️")) << '\t'
+           << (e.fromIrc && e.fromEventSub ? QStringLiteral("📝🧩") : (e.fromEventSub ? QStringLiteral("🧩") : QStringLiteral("📝"))) << '\t'
            << e.timestamp.toString(Qt::ISODate) << '\t'
            << e.command << '\t'
            << e.sender << '\t'

--- a/twitchlogmodel.h
+++ b/twitchlogmodel.h
@@ -12,7 +12,7 @@
 class TwitchLogModel : public QAbstractTableModel {
     Q_OBJECT
 public:
-    enum Columns { Direction = 0, Timestamp, Command, Sender, Message, Tags, Emotes, ColumnCount };
+    enum Columns { Direction = 0, Source, Timestamp, Command, Sender, Message, Tags, Emotes, ColumnCount };
     enum MsgDirection { Sent = 0, Received };
 
     struct Entry {
@@ -22,6 +22,8 @@ public:
         QString sender;
         QString message;
         QString tags;
+        bool fromIrc = true;
+        bool fromEventSub = false;
         QList<QPixmap> emotes;
         QStringList pendingEmotes;
     };
@@ -38,6 +40,8 @@ public:
                   const QString &sender,
                   const QString &message,
                   const QString &tags,
+                  bool fromIrc = true,
+                  bool fromEventSub = false,
                   const QList<QPixmap> &emotes = QList<QPixmap>(),
                   const QStringList &pendingEmotes = QStringList());
 


### PR DESCRIPTION
### Motivation
- Provide a compact visual indicator in the logs for the origin of each event (IRC, EventSub, or both correlated). 
- Make the origin obvious both at-a-glance (emoji column) and on hover (full-text tooltip). 
- Preserve origin information when exporting logs so offline inspection retains source context.

### Description
- Add a new `Source` column to `TwitchLogModel` and include it in `DEFAULT_LOG_COLUMNS` so it appears in the log view by default. 
- Extend `TwitchLogModel::Entry` with `fromIrc` and `fromEventSub` flags and update `addEntry` to accept and store these flags. 
- Render the source column as `📝` for IRC, `🧩` for EventSub, and `📝🧩` when both are correlated, and provide tooltip strings `Origin: IRC`, `Origin: EventSub`, and `Origin: IRC and EventSub`. 
- Pass correlation flags from merged `PRIVMSG` events in `TwitchChatReader` into the log model and include the emoji in exported log lines; ensure the `Source` column stays visible in the log dialog UI.

### Testing
- Attempted to build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed in this environment because Qt development packages are not available (`Qt6Config.cmake` / `qt6-config.cmake` not found`).
- No additional automated tests were present or executed in this environment; source-level changes were verified by local diff inspection and a successful commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0fb6c87c83288efec69e60bcb455)