### PR TITLE
Add tooltip for message text in log table

### DIFF
--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -61,6 +61,9 @@ QVariant TwitchLogModel::data(const QModelIndex &index, int role) const
         default:
             return QVariant();
         }
+    } else if (role == Qt::ToolTipRole) {
+        if (index.column() == Message)
+            return e.message;
     } else if (role == Qt::ForegroundRole) {
         auto it = m_fgColors.find(e.command);
         if (it != m_fgColors.end())


### PR DESCRIPTION
### Motivation
- Allow users to read full log messages on hover so they don't need to resize the "Message" column.

### Description
- Handle `Qt::ToolTipRole` in `TwitchLogModel::data` and return `e.message` when `index.column() == Message` in `twitchlogmodel.cpp`.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2`, and configuration/build failed due to missing Qt development package (`Qt6Config.cmake` not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae100b06e08328913891ff5a7ad5da)