### PR TITLE
Save logs continuously when auto-save is enabled

### DIFF
--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -230,28 +230,19 @@ void TwitchLogModel::maybeAutoSave() const
     if (!enabled)
         return;
 
-    const int periodMinutes = qMax(1, settings.value(CFG_LOG_AUTOSAVE_PERIOD_MIN, DEFAULT_LOG_AUTOSAVE_PERIOD_MIN).toInt());
-    const QDateTime now = QDateTime::currentDateTime();
-    if (m_lastAutoSave.isValid() && m_lastAutoSave.secsTo(now) < (periodMinutes * 60))
-        return;
-
     const QString directory = settings.value(CFG_LOG_AUTOSAVE_DIRECTORY, DEFAULT_LOG_AUTOSAVE_DIRECTORY).toString();
     const QString pattern = settings.value(CFG_LOG_AUTOSAVE_NAME_PATTERN, DEFAULT_LOG_AUTOSAVE_NAME_PATTERN).toString();
     const QString filePath = buildAutoSaveFilePath(directory, pattern);
     if (filePath.isEmpty())
         return;
 
-    if (m_autoSaveFilePath != filePath) {
-        m_autoSaveFilePath = filePath;
-        m_lastAutoSave = QDateTime();
-    }
+    m_autoSaveFilePath = filePath;
 
     QDir dir(directory);
     if (!dir.exists() && !dir.mkpath(QStringLiteral(".")))
         return;
 
-    if (exportToFile(m_autoSaveFilePath))
-        m_lastAutoSave = now;
+    exportToFile(m_autoSaveFilePath);
 }
 
 QString TwitchLogModel::connectionTimestampToken() const
@@ -263,5 +254,4 @@ void TwitchLogModel::setConnectionStartedAt(const QDateTime &timestamp)
 {
     m_connectionStartedAt = timestamp.isValid() ? timestamp : QDateTime::currentDateTime();
     m_autoSaveFilePath.clear();
-    m_lastAutoSave = QDateTime();
 }

--- a/twitchlogmodel.h
+++ b/twitchlogmodel.h
@@ -64,7 +64,6 @@ private:
     QVector<Entry> m_entries;
     QHash<QString, QColor> m_fgColors;
     QHash<QString, QColor> m_bgColors;
-    mutable QDateTime m_lastAutoSave;
     QDateTime m_connectionStartedAt;
     mutable QString m_autoSaveFilePath;
 };


### PR DESCRIPTION
### Motivation
- Change auto-save behavior so logs are persisted on every new entry when auto-save is enabled instead of being throttled by a user-configurable interval.
- Reduce the chance of losing recent logs between periodic saves by writing continuously.
- Remove interval-related state that is no longer required.

### Description
- Updated `TwitchLogModel::maybeAutoSave()` to remove the minute-based throttle and call `exportToFile()` on every invocation when auto-save is enabled.
- Always update `m_autoSaveFilePath` from `buildAutoSaveFilePath()` and keep the existing directory creation and file export flow intact.
- Removed the now-unused `m_lastAutoSave` member from `TwitchLogModel` and removed its reset in `setConnectionStartedAt()`.
- Kept file name/token generation logic unchanged (still uses `connectionTimestampToken()` and the configured pattern).

### Testing
- Attempted to configure and build the project with `cmake -S . -B build && cmake --build build -j2`, which failed due to missing Qt6 (`Qt6Config.cmake` not found).
- No other automated tests were run in this environment because the build could not complete due to the missing Qt dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f5e4d4748328ba52be7eea9a946a)