### PR TITLE
Fix profile loading version/refraction bugs affecting custom materials

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -568,6 +568,7 @@ void SetupWidget::loadSettings()
     ui->cboLanguage->setCurrentIndex(langIndex);
 
     // profiles
+    const int storedProfilesVersion = settings.value(CFG_PROFILES_VERSION, DEFAULT_PROFILES_VERSION).toInt();
     int size = settings.beginReadArray(CFG_PROFILES);
     if (size == 0) {
         settings.endArray();
@@ -602,7 +603,7 @@ void SetupWidget::loadSettings()
             ProfileData* profileData = new ProfileData;
             QString profileName = settings.value(CFG_PROFILE_NAME).toString();
 
-            int version = settings.value(CFG_PROFILES_VERSION, DEFAULT_PROFILES_VERSION).toInt();
+            int version = storedProfilesVersion;
             if (version < CURRENT_PROFILES_VERSION) {
                 // Backward compatibility: older releases stored the profile version inside each profile entry.
                 version = settings.value(CFG_VERSION, version).toInt();
@@ -645,7 +646,7 @@ void SetupWidget::loadSettings()
                 profileData->setMetalness(settings.value(CFG_METALNESS, DEFAULT_METALNESS).toInt());
                 int indexOfRefraction = settings.value(CFG_REFRACTION_TYPE, static_cast<int>(DEFAULT_REFRACTION_TYPE)).toInt();
                 profileData->setIndexOfRefractionType(static_cast<IndexOfRefraction>(indexOfRefraction));
-                profileData->setRefraction(settings.value(CFG_ROUGHNESS, DEFAULT_ROUGHNESS).toInt());
+                profileData->setRefraction(settings.value(CFG_REFRACTION, DEFAULT_REFRACTION).toInt());
 
                 // Specular Glossy Material
                 profileData->setSpecularColor(settings.value(CFG_COLORS_SPECULAR, DEFAULT_COLORS_SPECULAR).toString());


### PR DESCRIPTION
### Motivation
- Prevent custom material profiles from being misinterpreted as legacy v1 profiles which caused material type migration and loss of custom shader code when loading settings.

### Description
- Read `profiles/version` into `storedProfilesVersion` before iterating the profiles array so each profile is parsed with the intended schema version.
- Use `storedProfilesVersion` as the per-profile default and keep the per-profile `CFG_VERSION` lookup only as a backward-compatibility fallback.
- Fix a typo so `CFG_REFRACTION` is used when loading refraction instead of reading from `CFG_ROUGHNESS`.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but configuration failed because Qt6 development files are not available in this environment, so no successful build or unit test execution was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f5ac3e4083288cb7e6a77c6d74c1)