### PR TITLE
Set default log autosave directory to `logs/` and centralize default

### DIFF
--- a/settings_defaults.h
+++ b/settings_defaults.h
@@ -18,6 +18,7 @@
 #define SETTINGS_DEFAULTS_H
 
 #include <QtGlobal>
+#include <QDir>
 
 
 #define CFG_VERSION "version"
@@ -68,8 +69,12 @@
 #define DEFAULT_LOG_COLUMNS (QStringList() << "Direction" << "Source" << "Timestamp" << "Command" << "Sender" << "Message" << "Tags" << "Emotes")
 #define DEFAULT_LOG_AUTOSAVE_ENABLED false
 #define DEFAULT_LOG_AUTOSAVE_PERIOD_MIN 5
-#define DEFAULT_LOG_AUTOSAVE_DIRECTORY ""
 #define DEFAULT_LOG_AUTOSAVE_NAME_PATTERN "atsumari_${timestamp}.txt"
+
+inline QString defaultLogAutosaveDirectory()
+{
+    return QDir::current().absoluteFilePath(QStringLiteral("logs"));
+}
 
 #define DEFAULT_LOG_COMMANDS (QStringList() << "001" << "002" << "003" << "004" << "353" << "366" << "372" << "375" << "376" \
                                        << "CAP" << "CLEARCHAT" << "CLEARMSG" << "GLOBALUSERSTATE" << "JOIN" << "NICK" << "NOTICE" \

--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -1301,7 +1301,7 @@ void SetupWidget::loadLogSettings()
 
     ui->chkLogAutosaveEnabled->setChecked(settings.value(CFG_LOG_AUTOSAVE_ENABLED, DEFAULT_LOG_AUTOSAVE_ENABLED).toBool());
     ui->spnLogAutosavePeriod->setValue(settings.value(CFG_LOG_AUTOSAVE_PERIOD_MIN, DEFAULT_LOG_AUTOSAVE_PERIOD_MIN).toInt());
-    ui->edtLogAutosaveDirectory->setText(settings.value(CFG_LOG_AUTOSAVE_DIRECTORY, DEFAULT_LOG_AUTOSAVE_DIRECTORY).toString());
+    ui->edtLogAutosaveDirectory->setText(settings.value(CFG_LOG_AUTOSAVE_DIRECTORY, defaultLogAutosaveDirectory()).toString());
     ui->edtLogAutosavePattern->setText(settings.value(CFG_LOG_AUTOSAVE_NAME_PATTERN, DEFAULT_LOG_AUTOSAVE_NAME_PATTERN).toString());
 
     auto applyAutosaveEnabled = [=]() {

--- a/twitchlogmodel.cpp
+++ b/twitchlogmodel.cpp
@@ -235,7 +235,7 @@ void TwitchLogModel::maybeAutoSave() const
     if (m_lastAutoSave.isValid() && m_lastAutoSave.secsTo(now) < (periodMinutes * 60))
         return;
 
-    const QString directory = settings.value(CFG_LOG_AUTOSAVE_DIRECTORY, DEFAULT_LOG_AUTOSAVE_DIRECTORY).toString();
+    const QString directory = settings.value(CFG_LOG_AUTOSAVE_DIRECTORY, defaultLogAutosaveDirectory()).toString();
     const QString pattern = settings.value(CFG_LOG_AUTOSAVE_NAME_PATTERN, DEFAULT_LOG_AUTOSAVE_NAME_PATTERN).toString();
     const QString filePath = buildAutoSaveFilePath(directory, pattern);
     if (filePath.isEmpty())


### PR DESCRIPTION
### Motivation
- Provide a sensible default for log autosave directory instead of an empty string and centralize the default so multiple callers use the same value.

### Description
- Add `defaultLogAutosaveDirectory()` (uses `QDir::current().absoluteFilePath("logs")`) and include `<QDir>`, remove the empty-string macro default, and update `SetupWidget::loadLogSettings()` and `TwitchLogModel::maybeAutoSave()` to use `defaultLogAutosaveDirectory()` when reading `CFG_LOG_AUTOSAVE_DIRECTORY`.

### Testing
- Built the project (`qmake && make`) successfully to ensure the changes compile and the new default is applied at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6f50a0a10832884cec23a17320018)