### PR TITLE
Prevent duplicate EventSub websocket reconnects and subscriptions

### DIFF
--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -67,8 +67,17 @@ TwitchChatReader::TwitchChatReader(const QString &ircUrl,
     connect(m_eventSubSocket, &QWebSocket::textMessageReceived, this, &TwitchChatReader::onEventSubTextMessageReceived);
     connect(m_eventSubSocket, &QWebSocket::errorOccurred, this, [=](QAbstractSocket::SocketError error) { qDebug() << "EventSub error:" << error; });
     connect(m_eventSubSocket, &QWebSocket::disconnected, this, [=]() {
-        if (!m_waitingForTokenRefresh)
-            QTimer::singleShot(2000, this, &TwitchChatReader::setupEventSub);
+        m_eventSubSessionId.clear();
+        m_eventSubSubscriptionId.clear();
+        m_eventSubSubscriptionInFlight = false;
+        if (m_waitingForTokenRefresh || m_eventSubReconnectScheduled)
+            return;
+        m_eventSubReconnectScheduled = true;
+        QTimer::singleShot(2000, this, [this]() {
+            m_eventSubReconnectScheduled = false;
+            if (!m_waitingForTokenRefresh && m_eventSubSocket->state() == QAbstractSocket::UnconnectedState)
+                setupEventSub();
+        });
     });
 
     m_webSocket->open(QUrl(ircUrl + "?oauth_token=" + m_token));
@@ -84,6 +93,7 @@ void TwitchChatReader::setAccessToken(const QString &token)
 
     m_token = token;
     m_waitingForTokenRefresh = false;
+    m_eventSubSubscriptionInFlight = false;
 
     if (m_eventSubSocket->state() != QAbstractSocket::ConnectedState)
         setupEventSub();
@@ -177,7 +187,15 @@ void TwitchChatReader::onIrcTextMessageReceived(const QString &allMsgs)
 
 void TwitchChatReader::setupEventSub()
 {
+    if (m_waitingForTokenRefresh || m_token.isEmpty())
+        return;
+
+    if (m_eventSubSocket->state() != QAbstractSocket::UnconnectedState)
+        return;
+
     m_eventSubSessionId.clear();
+    m_eventSubSubscriptionId.clear();
+    m_eventSubSubscriptionInFlight = false;
     m_eventSubSocket->open(QUrl(QStringLiteral("wss://eventsub.wss.twitch.tv/ws")));
 }
 
@@ -197,6 +215,8 @@ void TwitchChatReader::onEventSubTextMessageReceived(const QString &payload)
 
     if (type == QStringLiteral("session_welcome")) {
         m_eventSubSessionId = root.value("payload").toObject().value("session").toObject().value("id").toString();
+        m_eventSubSubscriptionId.clear();
+        m_eventSubSubscriptionInFlight = false;
         if (!m_eventSubSessionId.isEmpty())
             createChannelChatMessageSubscription();
         return;
@@ -254,6 +274,8 @@ void TwitchChatReader::createChannelChatMessageSubscription()
 {
     if (m_eventSubSessionId.isEmpty() || m_broadcasterId.isEmpty() || m_userId.isEmpty())
         return;
+    if (m_eventSubSubscriptionInFlight || !m_eventSubSubscriptionId.isEmpty())
+        return;
 
     QSettings settings;
     QString clientId = settings.value(CFG_CLIENT_ID, DEFAULT_CLIENT_ID).toString();
@@ -271,8 +293,10 @@ void TwitchChatReader::createChannelChatMessageSubscription()
         {"transport", QJsonObject{{"method", "websocket"}, {"session_id", m_eventSubSessionId}}}
     };
 
+    m_eventSubSubscriptionInFlight = true;
     QNetworkReply *reply = m_network.post(request, QJsonDocument(payload).toJson(QJsonDocument::Compact));
     connect(reply, &QNetworkReply::finished, this, [this, reply]() {
+        m_eventSubSubscriptionInFlight = false;
         if (reply->error() != QNetworkReply::NoError) {
             const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
             qWarning() << "Failed to subscribe to EventSub:" << reply->readAll();
@@ -280,6 +304,19 @@ void TwitchChatReader::createChannelChatMessageSubscription()
                 m_waitingForTokenRefresh = true;
                 m_eventSubSocket->close();
             }
+            if (status == 429) {
+                m_eventSubSubscriptionId = QStringLiteral("rate-limited");
+            }
+            reply->deleteLater();
+            return;
+        }
+
+        const QJsonDocument responseJson = QJsonDocument::fromJson(reply->readAll());
+        const QJsonArray data = responseJson.object().value("data").toArray();
+        if (!data.isEmpty()) {
+            const QString id = data.first().toObject().value("id").toString();
+            if (!id.isEmpty())
+                m_eventSubSubscriptionId = id;
         }
         reply->deleteLater();
     });

--- a/twitchchatreader.h
+++ b/twitchchatreader.h
@@ -106,9 +106,12 @@ private:
     QString m_broadcasterId;
     QString m_userId;
     QString m_eventSubSessionId;
+    QString m_eventSubSubscriptionId;
     QTimer* m_pingTimer = nullptr;
     int m_reconnectAttempts = 0;
     bool m_waitingForTokenRefresh = false;
+    bool m_eventSubReconnectScheduled = false;
+    bool m_eventSubSubscriptionInFlight = false;
 
     EmojiMapper m_emojiMapper;
     EmoteWriter* m_emoteWriter;


### PR DESCRIPTION
### Motivation
- The app was opening multiple EventSub websocket connections and issuing repeated subscription POSTs which led to `429 Too Many Requests` errors.
- Reconnects could be scheduled multiple times on disconnect, causing reconnection storms and duplicate subscription attempts.
- Subscription lifecycle was not tracked, so repeated subscribe calls were sent for the same session.

### Description
- Added `m_eventSubSubscriptionId`, `m_eventSubReconnectScheduled`, and `m_eventSubSubscriptionInFlight` fields to track subscription state and debounce reconnects in `twitchchatreader.h`.
- On EventSub disconnect the session/subscription state is cleared and a single reconnect timer is scheduled using `m_eventSubReconnectScheduled` to prevent multiple timers, and `setupEventSub()` now only opens the websocket when truly disconnected and not waiting for token refresh.
- `createChannelChatMessageSubscription()` now guards against duplicate posts by returning early if a subscription is already in-flight or an id exists, and sets `m_eventSubSubscriptionInFlight` while the network request is active.
- Subscription responses handle `429` by persisting a rate-limited sentinel into `m_eventSubSubscriptionId`, and successful responses store the created subscription id; token refresh and `session_welcome` reset the relevant flags so flows remain correct.

### Testing
- Ran `cmake -S . -B build && cmake --build build -j2`, which failed in this environment because Qt6 is not installed (build system error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d84f633a2483288a997ea37578b1c2)