### PR TITLE
Use dedicated single-shot timer to prevent duplicate IRC reconnects

### DIFF
--- a/twitchchatreader.cpp
+++ b/twitchchatreader.cpp
@@ -50,6 +50,12 @@ TwitchChatReader::TwitchChatReader(const QString &ircUrl,
 {
     m_webSocket->setParent(this);
     m_eventSubSocket->setParent(this);
+    m_ircReconnectTimer = new QTimer(this);
+    m_ircReconnectTimer->setSingleShot(true);
+    connect(m_ircReconnectTimer, &QTimer::timeout, this, [this, ircUrl]() {
+        if (m_webSocket->state() == QAbstractSocket::UnconnectedState)
+            m_webSocket->open(QUrl(ircUrl + "?oauth_token=" + m_token));
+    });
 
     connect(m_webSocket, &QWebSocket::connected, this, &TwitchChatReader::onIrcConnected);
     connect(m_webSocket, &QWebSocket::errorOccurred, this, [=](QAbstractSocket::SocketError error) { qDebug() << "IRC error:" << error; });
@@ -58,9 +64,7 @@ TwitchChatReader::TwitchChatReader(const QString &ircUrl,
     connect(m_webSocket, &QWebSocket::disconnected, this, [=] {
         ++m_reconnectAttempts;
         int delay = qMin(30000, 1000 * (1 << (m_reconnectAttempts - 1)));
-        QTimer::singleShot(delay, this, [=] {
-            m_webSocket->open(QUrl(ircUrl + "?oauth_token=" + m_token));
-        });
+        m_ircReconnectTimer->start(delay);
     });
 
     connect(m_eventSubSocket, &QWebSocket::connected, this, &TwitchChatReader::onEventSubConnected);
@@ -117,6 +121,7 @@ TwitchChatReader::~TwitchChatReader()
 
 void TwitchChatReader::onIrcConnected()
 {
+    m_ircReconnectTimer->stop();
     m_reconnectAttempts = 0;
     emit connected();
 

--- a/twitchchatreader.h
+++ b/twitchchatreader.h
@@ -108,6 +108,7 @@ private:
     QString m_eventSubSessionId;
     QString m_eventSubSubscriptionId;
     QTimer* m_pingTimer = nullptr;
+    QTimer* m_ircReconnectTimer = nullptr;
     int m_reconnectAttempts = 0;
     bool m_waitingForTokenRefresh = false;
     bool m_eventSubReconnectScheduled = false;


### PR DESCRIPTION
### Motivation
- Prevent stale delayed reconnect callbacks from firing after the IRC WebSocket has successfully reconnected, which caused multiple consecutive connection attempts.

### Description
- Added a new `QTimer* m_ircReconnectTimer` member to `TwitchChatReader` and initialized it as a single-shot timer in the constructor.
- Replaced ad-hoc `QTimer::singleShot(...)` reconnect scheduling with `m_ircReconnectTimer->start(delay)` on disconnect.
- Added a guard in the reconnect timer callback to only call `open(...)` when the socket is still in `QAbstractSocket::UnconnectedState`.
- Stop the pending reconnect timer in `onIrcConnected()` and preserve the existing reconnect-attempt reset logic.

### Testing
- Attempted to configure and build with `cmake -S . -B build && cmake --build build -j2`, but the build failed because the environment is missing the Qt6 development packages (`Qt6Config.cmake` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9892fba88328b826545e7b333c55)