### PR TITLE
Add warning for newer persisted settings versions

### DIFF
--- a/setupwidget.cpp
+++ b/setupwidget.cpp
@@ -50,6 +50,7 @@
 #include <QJsonObject>
 #include <QVersionNumber>
 #include <QTimer>
+#include <QCoreApplication>
 #include <QPointer>
 #include <QMetaObject>
 #include <QMutex>
@@ -559,6 +560,25 @@ void SetupWidget::loadSettings()
 {
     QSettings settings;
 
+    const int savedSettingsVersion = settings.value(CFG_VERSION, CURRENT_PROFILES_VERSION).toInt();
+    if (savedSettingsVersion > CURRENT_PROFILES_VERSION) {
+        const QMessageBox::StandardButton choice = QMessageBox::warning(
+            this,
+            tr("Newer settings version detected"),
+            tr("This installation has settings created by a newer version of Atsumari. "
+               "Some data may be incompatible with this version. Do you want to continue anyway?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No
+        );
+
+        if (choice == QMessageBox::No) {
+            QTimer::singleShot(0, []() {
+                QCoreApplication::quit();
+            });
+            return;
+        }
+    }
+
     // Appearance & Behavior
     QLocale defaultLocale = settings.value(CFG_LANGUAGE, LocaleHelper::findBestLocale()).toLocale();
     int langIndex = ui->cboLanguage->findData(defaultLocale);
@@ -685,6 +705,7 @@ void SetupWidget::saveSettings()
 {
     bool fontWarn = false;
     QSettings settings;
+    settings.setValue(CFG_VERSION, CURRENT_PROFILES_VERSION);
     settings.setValue(CFG_LANGUAGE, ui->cboLanguage->currentData());
     settings.setValue(CFG_CURRENT_PROFILE, m_currentProfile);
     settings.setValue(CFG_PROFILES_VERSION, CURRENT_PROFILES_VERSION);


### PR DESCRIPTION
### Motivation
- Prevent silent loading of settings created by a newer Atsumari release by detecting a higher `version` in `QSettings` and prompting the user before proceeding.

### Description
- In `setupwidget.cpp` added a root-level check in `SetupWidget::loadSettings()` that reads `CFG_VERSION` from `QSettings` and compares it against `CURRENT_PROFILES_VERSION`, showing a `QMessageBox::warning` if the saved version is newer.
- The warning offers `Yes`/`No`; choosing `No` schedules `QCoreApplication::quit()` and aborts loading, while `Yes` continues normal loading.
- Persist the root `CFG_VERSION` in `saveSettings()` by setting it to `CURRENT_PROFILES_VERSION` so future runs can compare correctly.
- Added an include for `<QCoreApplication>` to support the exit path; all changes are in `setupwidget.cpp`.

### Testing
- Ran a CMake configure/build attempt with `cmake -S . -B build && cmake --build build -j2`, which failed because the environment is missing Qt development packages (`Qt6Config.cmake` not found), so no compiled tests could be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69af63604a008328baaf45945915cf57)